### PR TITLE
AMI command processing and skinny lines/devices function

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ To get the state of an extension use the following command
 ```ruby
  @ami.extension_state(@exten,@context)
 ```
+### Skinny devices and lines
+
+To get list of skinny devices
+
+```ruby
+ @ami.skinny_devices
+```
+
+To get list of skinny lines
+
+```ruby
+ @ami.skinny_lines
+```
 
 ### THE RESPONSE OBJECT
 

--- a/lib/ruby-asterisk.rb
+++ b/lib/ruby-asterisk.rb
@@ -103,6 +103,28 @@ module RubyAsterisk
       Response.new("ExtensionState",request.response_data)
     end
 
+    def skinny_devices
+      request = Request.new("SKINNYdevices")
+      request.commands.each do |c|
+        @session.write(c)
+      end
+      @session.waitfor("Match" => /ActionID: #{request.action_id}\n\n/, "Timeout" => 3) do |data|
+        request.response_data << data
+      end
+      Response.new("SKINNYdevices",request.response_data)
+    end
+    
+    def skinny_lines
+      request = Request.new("SKINNYlines")
+      request.commands.each do |c|
+        @session.write(c)
+      end
+      @session.waitfor("Match" => /ActionID: #{request.action_id}\n\n/, "Timeout" => 3) do |data|
+        request.response_data << data
+      end
+      Response.new("SKINNYlines",request.response_data)
+    end
+
     def originate(caller,context,callee,priority,variable=nil)
       request = Request.new("Originate",{"Channel" => caller, "Context" => context, "Exten" => callee, "Priority" => priority, "Callerid" => caller, "Timeout" => "30000", "Variable" => variable  })
       request.commands.each do |command|

--- a/lib/ruby-asterisk/response.rb
+++ b/lib/ruby-asterisk/response.rb
@@ -46,6 +46,12 @@ module RubyAsterisk
           self._parse_meet_me_list(response)
         when "ExtensionState"
           self._parse_extension_state(response)
+         when "SKINNYdevices"
+          self._parse_skinny_devices(response)
+        when "SKINNYlines"
+          self._parse_skinny_lines(response)
+        when "Command"
+          response
       end
     end
 
@@ -68,6 +74,14 @@ module RubyAsterisk
     def _parse_extension_state(response)
       _data = self._parse_objects(response,:hints,"Response:")
       self._convert_status(_data)
+    end
+    
+    def _parse_skinny_devices(response)
+      self._parse_objects(response,:skinnydevs,"Event: DeviceEntry")
+    end
+
+    def _parse_skinny_lines(response)
+      self._parse_objects(response,:skinnylines,"Event: LineEntry")
     end
 
     def _convert_status(_data)


### PR DESCRIPTION
Hello,

There is an update for method RubyAsterisk::AMI#command
@session.waitfor should wait for "--END COMMAND--" string to get all command output.

Two new functions to get skinny devices and lines.
README updated.

Best regards,
Stas
