### PR TITLE
Response parse fix and response delimiter

### DIFF
--- a/lib/ruby-asterisk.rb
+++ b/lib/ruby-asterisk.rb
@@ -64,7 +64,7 @@ module RubyAsterisk
       request.commands.each do |command|
         @session.write(command)
       end
-      @session.waitfor("String" => "ActionID: "+request.action_id, "Timeout" => 3) do |data|
+      @session.waitfor("String" => "ActionID: #{request.action_id}\n\n", "Timeout" => 3) do |data|
         request.response_data << data
       end
       Response.new("CoreShowChannels",request.response_data)

--- a/lib/ruby-asterisk/response.rb
+++ b/lib/ruby-asterisk/response.rb
@@ -118,7 +118,8 @@ module RubyAsterisk
           object = {}
           parsing = true
         elsif parsing
-          object[line.split(':')[0].strip]=line.split(':')[1].strip unless line.split(':')[1].nil?
+          tokens = line.split(':', 2)
+          object[tokens[0].strip]=tokens[1].strip unless tokens[1].nil?
         end
       end
       _data[symbol_name] << object unless object.nil?


### PR DESCRIPTION
When the returned data contains lines such as below with multiple semicolons,  only partial data is collected due to line.split(':') picking up only the first two values in Duration:

<pre>
Action ID: 345
Duration: 10:03:12</pre>


Also to read data completely, telnet must wait for two newlines after ActionID: 223 otherwise only partial data is returned.
