### PR TITLE
originate_app

### DIFF
--- a/lib/ruby-asterisk.rb
+++ b/lib/ruby-asterisk.rb
@@ -79,6 +79,10 @@ module RubyAsterisk
       execute 'Originate', {'Channel' => caller, 'Context' => context, 'Exten' => callee, 'Priority' => priority, 'Callerid' => caller, 'Timeout' => '30000', 'Variable' => variable  }
     end
 
+    def originate_app(caller, app, data, async)
+      execute 'Originate', {'Channel' => caller, 'Application' => app, 'Data' => data, 'Timeout' => '30000', 'Async' => async }
+    end
+
     def channels
       execute 'Command', { 'Command' => 'show channels' }
     end

--- a/lib/ruby-asterisk/version.rb
+++ b/lib/ruby-asterisk/version.rb
@@ -1,3 +1,3 @@
 module Rami
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Hello @all.

I have added originate_app. 
It can be used like this:
@ami.originate_app("SIP/#{number}", "Macro", "macroname,#{macroarg1}", "True")
Parameters are: Channel, Application, Data, Async

Please consider pushing it into main code.
