### PR TITLE
Adding support for a SIPshowregistry AMI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ To get info of a peer (equivalent to "sip show peer" call on the asterisk server
  @ami.sip_show_peer(peer)
 ```
 
+### SIP SHOW REGISTRY
+
+Retrieve a status of SIP registries and their statuses from the Asterisk server.
+
+```ruby
+ @ami.sip_show_registry
+```
+
 ### STATUS
                                                                                                                         
 To get a status of a single channel or for all channels                                                                                                                                  

--- a/lib/ruby-asterisk.rb
+++ b/lib/ruby-asterisk.rb
@@ -208,6 +208,10 @@ module RubyAsterisk
       execute 'ChangeMonitor', {'Channel' => channel, 'File' => file}
     end
 
+    def sip_show_registry
+      execute 'SIPshowregistry'
+    end
+
     private
     def execute(command, options = {})
       request = Request.new(command, options)


### PR DESCRIPTION
This should be fairly straightforward. I'm looking to create a Sensu check on my Asterisk server that will poll trunk statuses. I'm using your ruby-asterisk library to get data from AMI, but need to be able to query on the SIPshowregistry AMI command.

I've added an example in the README.md file on the usage as well.