### PR TITLE
Issue #43 - Adding Rubocop linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,23 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Linting
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Run Rubocop
+        run: bundle exec rubocop
+
   test:
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -34,7 +50,7 @@ jobs:
         run: bundle exec rake spec
 
   release:
-    needs: test
+    needs: [lint, test]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+plugins:
+  - rubocop-performance
+
+AllCops:
+  TargetRubyVersion: 3.1
+  NewCops: enable
+  SuggestExtensions: false
+
+# Crucial for Ractor compatibility - all files must have frozen string literal comment
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
+# Enforce single quotes unless interpolation is needed
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: single_quotes
+
+# Set reasonable limits but exclude the legacy AMI class
+Metrics/ClassLength:
+  Enabled: true
+  Max: 100
+  Exclude:
+    - 'lib/ruby-asterisk.rb'
+
+# Reasonable method length
+Metrics/MethodLength:
+  Enabled: true
+  Max: 15
+  Exclude:
+    - 'spec/**/*'
+
+# Allow longer blocks in specs
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - '*.gemspec'
+
+# Allow longer lines for readability in some cases
+Layout/LineLength:
+  Max: 120
+  Exclude:
+    - 'spec/**/*'
+
+# Gemspec file uses string literals from git commands
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
+# Exclude legacy AMI class from parameter list checks until refactored
+Metrics/ParameterLists:
+  Exclude:
+    - 'lib/ruby-asterisk.rb'
+
+# Exclude legacy AMI class from optional boolean parameter checks
+Style/OptionalBooleanParameter:
+  Exclude:
+    - 'lib/ruby-asterisk.rb'
+
+# The gem filename follows rubygems convention (gem-name.rb)
+Naming/FileName:
+  Exclude:
+    - 'lib/ruby-asterisk.rb'
+
+# Exclude response parser complexity until refactored
+Metrics/AbcSize:
+  Exclude:
+    - 'lib/ruby-asterisk/response_parser.rb'
+
+# Keep `success` method name for backwards compatibility (not success?)
+Naming/PredicateMethod:
+  Exclude:
+    - 'lib/ruby-asterisk/response.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rami.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
 require 'rspec'
 require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:spec) 
+RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec

--- a/lib/ruby-asterisk.rb
+++ b/lib/ruby-asterisk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ruby-asterisk/version'
 require 'ruby-asterisk/request'
 require 'ruby-asterisk/response'
@@ -21,28 +23,24 @@ module RubyAsterisk
     end
 
     def connect
-      begin
-        @session = Net::Telnet::new('Host' => self.host, 'Port' => self.port, 'Timeout' => 10)
-        self.connected = true
-      rescue Exception => ex
-        false
-      end
+      @session = Net::Telnet.new('Host' => host, 'Port' => port, 'Timeout' => 10)
+      self.connected = true
+    rescue StandardError
+      false
     end
 
     def disconnect
-      begin
-        @session.close if self.connected
-        self.connected = false
-        true
-      rescue Exception => ex
-        puts ex
-        false
-      end
+      @session.close if connected
+      self.connected = false
+      true
+    rescue StandardError => e
+      puts e
+      false
     end
 
     def login(username, password)
-      self.connect unless self.connected
-      execute 'Login', {'Username' => username, 'Secret' => password, 'Event' => 'On'}
+      connect unless connected
+      execute 'Login', { 'Username' => username, 'Secret' => password, 'Event' => 'On' }
     end
 
     def logoff
@@ -50,7 +48,7 @@ module RubyAsterisk
     end
 
     def command(command)
-      execute 'Command', {'Command' => command}
+      execute 'Command', { 'Command' => command }
     end
 
     def core_show_channels
@@ -66,19 +64,19 @@ module RubyAsterisk
     end
 
     def confbridge(conference)
-      execute 'ConfbridgeList', {'Conference' => conference}
+      execute 'ConfbridgeList', { 'Conference' => conference }
     end
 
     def confbridge_mute(conference, channel)
-      execute 'ConfbridgeMute', {'Conference' => conference, 'Channel' => channel}
+      execute 'ConfbridgeMute', { 'Conference' => conference, 'Channel' => channel }
     end
 
     def confbridge_unmute(conference, channel)
-      execute 'ConfbridgeUnmute', {'Conference' => conference, 'Channel' => channel}
+      execute 'ConfbridgeUnmute', { 'Conference' => conference, 'Channel' => channel }
     end
 
     def confbridge_kick(conference, channel)
-      execute 'ConfbridgeKick', {'Conference' => conference, 'Channel' => channel}
+      execute 'ConfbridgeKick', { 'Conference' => conference, 'Channel' => channel }
     end
 
     def parked_calls
@@ -86,9 +84,9 @@ module RubyAsterisk
     end
 
     def extension_state(exten, context, action_id = nil)
-      execute 'ExtensionState', {'Exten' => exten, 'Context' => context, 'ActionID' => action_id}
+      execute 'ExtensionState', { 'Exten' => exten, 'Context' => context, 'ActionID' => action_id }
     end
-    
+
     def device_state_list
       execute 'DeviceStateList'
     end
@@ -102,25 +100,31 @@ module RubyAsterisk
     end
 
     def status(channel = nil, action_id = nil)
-      execute 'Status', {'Channel' => channel, 'ActionID' => action_id}
+      execute 'Status', { 'Channel' => channel, 'ActionID' => action_id }
     end
 
-    def originate(channel, context, callee, priority, variable = nil, caller_id = nil, timeout = 30000, async = nil)
-      @timeout = [@timeout, timeout/1000].max
-      execute 'Originate', {'Channel' => channel, 'Context' => context, 'Exten' => callee, 'Priority' => priority, 'CallerID' => caller_id || channel, 'Timeout' => timeout.to_s, 'Variable' => variable, 'Async' => async }
+    def originate(channel, context, callee, priority, variable = nil, caller_id = nil, timeout = 30_000, async = nil)
+      @timeout = [@timeout, timeout / 1000].max
+      execute 'Originate',
+              { 'Channel' => channel, 'Context' => context, 'Exten' => callee, 'Priority' => priority,
+                'CallerID' => caller_id || channel, 'Timeout' => timeout.to_s, 'Variable' => variable,
+                'Async' => async }
     end
 
     def originate_app(caller, app, data, async)
-      execute 'Originate', {'Channel' => caller, 'Application' => app, 'Data' => data, 'Timeout' => '30000', 'Async' => async }
+      execute 'Originate',
+              { 'Channel' => caller, 'Application' => app, 'Data' => data, 'Timeout' => '30000', 'Async' => async }
     end
 
     def channels
       execute 'Command', { 'Command' => 'show channels' }
     end
 
-    def redirect(channel, context, callee, priority, variable=nil, caller_id = nil, timeout = 30000)
-      @timeout = [@timeout, timeout/1000].max
-      execute 'Redirect', {'Channel' => channel, 'Context' => context, 'Exten' => callee, 'Priority' => priority, 'CallerID' => caller_id || channel, 'Timeout' => timeout.to_s, 'Variable' => variable}
+    def redirect(channel, context, callee, priority, variable = nil, caller_id = nil, timeout = 30_000)
+      @timeout = [@timeout, timeout / 1000].max
+      execute 'Redirect',
+              { 'Channel' => channel, 'Context' => context, 'Exten' => callee, 'Priority' => priority,
+                'CallerID' => caller_id || channel, 'Timeout' => timeout.to_s, 'Variable' => variable }
     end
 
     def queues
@@ -128,15 +132,13 @@ module RubyAsterisk
     end
 
     def queue_add(queue, exten, penalty = 2, paused = false, member_name = '')
-      execute 'QueueAdd', {'Queue' => queue, 'Interface' => exten, 'Penalty' => penalty, 'Paused' => paused, 'MemberName' => member_name}
-    end
-
-    def queue_pause(exten, paused)
-      execute 'QueuePause', {'Interface' => exten, 'Paused' => paused}
+      execute 'QueueAdd',
+              { 'Queue' => queue, 'Interface' => exten, 'Penalty' => penalty, 'Paused' => paused,
+                'MemberName' => member_name }
     end
 
     def queue_remove(queue, exten)
-      execute 'QueueRemove', {'Queue' => queue, 'Interface' => exten}
+      execute 'QueueRemove', { 'Queue' => queue, 'Interface' => exten }
     end
 
     def queue_status
@@ -144,68 +146,68 @@ module RubyAsterisk
     end
 
     def queue_summary(queue)
-      execute 'QueueSummary', {'Queue' => queue}
+      execute 'QueueSummary', { 'Queue' => queue }
     end
 
-    def mailbox_status(exten, context='default')
-      execute 'MailboxStatus', {'Mailbox' => "#{exten}@#{context}"}
+    def mailbox_status(exten, context = 'default')
+      execute 'MailboxStatus', { 'Mailbox' => "#{exten}@#{context}" }
     end
 
-    def mailbox_count(exten, context='default')
-      execute 'MailboxCount', {'Mailbox' => "#{exten}@#{context}"}
+    def mailbox_count(exten, context = 'default')
+      execute 'MailboxCount', { 'Mailbox' => "#{exten}@#{context}" }
     end
 
-    def queue_pause(interface,paused,queue,reason='none')
-      execute 'QueuePause', {'Interface' => interface, 'Paused' => paused, 'Queue' => queue, 'Reason' => reason}
+    def queue_pause(interface, paused, queue, reason = 'none')
+      execute 'QueuePause', { 'Interface' => interface, 'Paused' => paused, 'Queue' => queue, 'Reason' => reason }
     end
 
     def ping
       execute 'Ping'
     end
 
-    def event_mask(event_mask='off')
-      execute 'Events', {'EventMask' => event_mask}
+    def event_mask(event_mask = 'off')
+      execute 'Events', { 'EventMask' => event_mask }
     end
 
     def sip_peers
       execute 'SIPpeers'
     end
-    
+
     def sip_show_peer(peer)
-      execute 'SIPshowpeer', {'Peer' => peer}
+      execute 'SIPshowpeer', { 'Peer' => peer }
     end
-    
+
     def hangup(channel)
-      execute 'Hangup', {'Channel' => channel}
+      execute 'Hangup', { 'Channel' => channel }
     end
 
     def atxfer(channel, exten, context, priority = '1')
-      execute 'Atxfer', {'Channel' => channel, 'Exten' => exten.to_s, 'Context' => context, 'Priority' => priority}
+      execute 'Atxfer', { 'Channel' => channel, 'Exten' => exten.to_s, 'Context' => context, 'Priority' => priority }
     end
 
-    def wait_event(timeout=-1)
+    def wait_event(timeout = -1)
       @timeout = [@timeout, timeout].max
-      execute 'WaitEvent', {'Timeout' => timeout}
+      execute 'WaitEvent', { 'Timeout' => timeout }
     end
 
-    def monitor(channel,mix=false,file=nil,format='wav')
-      execute 'Monitor', {'Channel' => channel, 'File' => file, 'Mix' => mix}
+    def monitor(channel, mix = false, file = nil, _format = 'wav')
+      execute 'Monitor', { 'Channel' => channel, 'File' => file, 'Mix' => mix }
     end
 
     def stop_monitor(channel)
-      execute 'StopMonitor', {'Channel' => channel}
+      execute 'StopMonitor', { 'Channel' => channel }
     end
 
     def pause_monitor(channel)
-      execute 'PauseMonitor', {'Channel' => channel}
+      execute 'PauseMonitor', { 'Channel' => channel }
     end
 
     def unpause_monitor(channel)
-      execute 'UnpauseMonitor', {'Channel' => channel}
+      execute 'UnpauseMonitor', { 'Channel' => channel }
     end
 
-    def change_monitor(channel,file)
-      execute 'ChangeMonitor', {'Channel' => channel, 'File' => file}
+    def change_monitor(channel, file)
+      execute 'ChangeMonitor', { 'Channel' => channel, 'File' => file }
     end
 
     def sip_show_registry
@@ -213,12 +215,14 @@ module RubyAsterisk
     end
 
     private
+
     def execute(command, options = {})
       request = Request.new(command, options)
       request.commands.each do |command|
         @session.write(command)
       end
-      @session.waitfor('Match' => /ActionID: #{request.action_id}.*?\n\n/m, "Timeout" => @timeout, "Waittime" => @wait_time) do |data|
+      @session.waitfor('Match' => /ActionID: #{request.action_id}.*?\n\n/m, 'Timeout' => @timeout,
+                       'Waittime' => @wait_time) do |data|
         request.response_data << data.to_s
       end
       Response.new(command, request.response_data)

--- a/lib/ruby-asterisk/parsing_constants.rb
+++ b/lib/ruby-asterisk/parsing_constants.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 #
 # File containing parsing constants
@@ -11,88 +13,88 @@ module RubyAsterisk
     '3' => 'Unavailable',
     '4' => 'Ringing',
     '5' => 'On Hold'
-  }
+  }.freeze
 
   PARSE_DATA = {
     'CoreShowChannels' => {
-      :symbol => :channels,
-      :search_for => 'Event: CoreShowChannel',
-      :stop_with => 'Event: CoreShowChannelsComplete'
+      symbol: :channels,
+      search_for: 'Event: CoreShowChannel',
+      stop_with: 'Event: CoreShowChannelsComplete'
     },
     'ParkedCalls' => {
-      :symbol => :calls,
-      :search_for => 'Event: ParkedCall',
-      :stop_with => nil
+      symbol: :calls,
+      search_for: 'Event: ParkedCall',
+      stop_with: nil
     },
-    'Originate'  => {
-      :symbol => :dial,
-      :search_for => 'Event: Dial',
-      :stop_with => nil
+    'Originate' => {
+      symbol: :dial,
+      search_for: 'Event: Dial',
+      stop_with: nil
     },
-    'MeetMeList'  => {
-      :symbol => :rooms,
-      :search_for => 'Event: MeetmeList',
-      :stop_with => nil
+    'MeetMeList' => {
+      symbol: :rooms,
+      search_for: 'Event: MeetmeList',
+      stop_with: nil
     },
-    'ConfbridgeListRooms'  => {
-      :symbol => :rooms,
-      :search_for => 'Event: ConfbridgeListRooms',
-      :stop_with => nil
+    'ConfbridgeListRooms' => {
+      symbol: :rooms,
+      search_for: 'Event: ConfbridgeListRooms',
+      stop_with: nil
     },
-    'ConfbridgeList'  => {
-      :symbol => :channels,
-      :search_for => 'Event: ConfbridgeList',
-      :stop_with => nil
+    'ConfbridgeList' => {
+      symbol: :channels,
+      search_for: 'Event: ConfbridgeList',
+      stop_with: nil
     },
-    'Status'  => {
-      :symbol => :status,
-      :search_for => 'Event: Status',
-      :stop_with => nil
+    'Status' => {
+      symbol: :status,
+      search_for: 'Event: Status',
+      stop_with: nil
     },
-    'ExtensionState'  => {
-      :symbol => :hints,
-      :search_for => 'Response: Success',
-      :stop_with => nil
+    'ExtensionState' => {
+      symbol: :hints,
+      search_for: 'Response: Success',
+      stop_with: nil
     },
-    'DeviceStateList'  => {
-      :symbol => :hints,
-      :search_for => 'Response: Success',
-      :stop_with => nil
+    'DeviceStateList' => {
+      symbol: :hints,
+      search_for: 'Response: Success',
+      stop_with: nil
     },
-    'SKINNYdevices'  => {
-      :symbol => :skinnydevs,
-      :search_for => 'Event: DeviceEntry',
-      :stop_with => nil
+    'SKINNYdevices' => {
+      symbol: :skinnydevs,
+      search_for: 'Event: DeviceEntry',
+      stop_with: nil
     },
     'SKINNYlines' => {
-      :symbol => :skinnylines,
-      :search_for => 'Event: LineEntry',
-      :stop_with => nil
+      symbol: :skinnylines,
+      search_for: 'Event: LineEntry',
+      stop_with: nil
     },
     'QueuePause' => {
-      :symbol => :queue_pause,
-      :search_for => 'Response:',
-      :stop_with => nil
+      symbol: :queue_pause,
+      search_for: 'Response:',
+      stop_with: nil
     },
     'Pong' => {
-      :symbol => :pong,
-      :search_for => 'Response:',
-      :stop_with => nil
+      symbol: :pong,
+      search_for: 'Response:',
+      stop_with: nil
     },
     'Events' => {
-      :symbol => :event_mask,
-      :search_for => 'Ping:',
-      :stop_with => nil
+      symbol: :event_mask,
+      search_for: 'Ping:',
+      stop_with: nil
     },
     'SIPpeers' => {
-      :symbol => :peers,
-      :search_for => 'Event: PeerEntry',
-      :stop_with => nil
+      symbol: :peers,
+      search_for: 'Event: PeerEntry',
+      stop_with: nil
     },
-    'SIPshowpeer'  => {
-      :symbol => :hints,
-      :search_for => 'Response: Success',
-      :stop_with => nil
-    },
-  }
+    'SIPshowpeer' => {
+      symbol: :hints,
+      search_for: 'Response: Success',
+      stop_with: nil
+    }
+  }.freeze
 end

--- a/lib/ruby-asterisk/request.rb
+++ b/lib/ruby-asterisk/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyAsterisk
   ##
   #
@@ -10,19 +12,17 @@ module RubyAsterisk
       self.action = action
       self.action_id = Request.generate_action_id
       self.parameters = parameters
-      self.response_data = ''
+      self.response_data = +''
     end
 
     def commands
-      _commands = ["Action: #{self.action}\r\n", "ActionID: #{self.action_id}\r\n"]
-      self.parameters.each do |key, value|
-        _commands<<"#{key.to_s}: #{value.to_s}\r\n" unless value.nil?
+      command_list = ["Action: #{action}\r\n", "ActionID: #{action_id}\r\n"]
+      parameters.each do |key, value|
+        command_list << "#{key}: #{value}\r\n" unless value.nil?
       end
-      _commands[_commands.length - 1] << "\r\n"
-      _commands
+      command_list[-1] << "\r\n"
+      command_list
     end
-
-    protected
 
     def self.generate_action_id
       Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond).to_s(36)

--- a/lib/ruby-asterisk/response.rb
+++ b/lib/ruby-asterisk/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ruby-asterisk/response_parser'
 
 module RubyAsterisk
@@ -8,42 +10,39 @@ module RubyAsterisk
   class Response
     attr_accessor :type, :action_id, :message, :data, :raw_response
 
-    def initialize(type,response)
+    def initialize(type, response)
       self.raw_response = [response].flatten
       self.type = type
-      self.action_id = self._parse_action_id
-      self.message = self._parse_message
-      self.data = self._parse_response
+      self.action_id = _parse_action_id
+      self.message = _parse_message
+      self.data = _parse_response
     end
 
     def success
-      self.raw_response.join.include?("Response: Success")
+      raw_response.join.include?('Response: Success')
     end
 
     protected
 
     def _parse_action_id
-      self._parse("ActionID:")
+      _parse('ActionID:')
     end
 
     def _parse_message
-      self._parse("Message:")
+      _parse('Message:')
     end
 
     def _parse(field)
-      self.raw_response.each do |data|
+      raw_response.each do |data|
         data.each_line do |line|
-          if line.start_with?(field)
-            return line[line.rindex(":")+1..line.size].strip
-          end
+          return line[(line.rindex(':') + 1)..line.size].strip if line.start_with?(field)
         end
       end
       nil
     end
 
     def _parse_response
-      ResponseParser.parse(self.raw_response, self.type)
+      ResponseParser.parse(raw_response, type)
     end
-
   end
 end

--- a/lib/ruby-asterisk/response_parser.rb
+++ b/lib/ruby-asterisk/response_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ruby-asterisk/parsing_constants'
 
 module RubyAsterisk
@@ -6,32 +8,29 @@ module RubyAsterisk
   # Class for parsing response coming from Asterisk
   #
   class ResponseParser
-
     def self.parse(raw_response, type)
       if PARSE_DATA.include?(type)
-        self._parse_objects(raw_response, PARSE_DATA[type])
+        _parse_objects(raw_response, PARSE_DATA[type])
       else
         raw_response
       end
     end
 
-    protected
-
     def self._add_status(exten_array)
       exten_array.each do |hint|
-        hint["DescriptiveStatus"] = DESCRIPTIVE_STATUS[hint["Status"]]
+        hint['DescriptiveStatus'] = DESCRIPTIVE_STATUS[hint['Status']]
       end
       exten_array
     end
 
     def self._parse_objects(response, parse_params)
       object_array = []
-      object_regex = Regexp.new(/#{parse_params[:search_for]}\n(.*?)\n\n/m)
+      object_regex = /#{parse_params[:search_for]}\n(.*?)\n\n/m
       response.join.scan(object_regex) do |match|
         object = {}
-        match[0].split(/\n/).each do |line|
+        match[0].split("\n").each do |line|
           tokens = line.split(':', 2)
-          object[tokens[0].strip]=tokens[1].strip unless tokens[1].nil?
+          object[tokens[0].strip] = tokens[1].strip unless tokens[1].nil?
         end
         object_array << object unless object.empty?
       end

--- a/lib/ruby-asterisk/version.rb
+++ b/lib/ruby-asterisk/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rami
-  VERSION = "0.2.0"
+  VERSION = '0.2.0'
 end

--- a/ruby-asterisk.gemspec
+++ b/ruby-asterisk.gemspec
@@ -1,24 +1,29 @@
-# -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "ruby-asterisk/version"
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
+require 'ruby-asterisk/version'
 
 Gem::Specification.new do |s|
-  s.name        = "ruby-asterisk"
+  s.name        = 'ruby-asterisk'
   s.version     = Rami::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Emiliano Della Casa"]
-  s.email       = ["emiliano.dellacasa@gmail.com"]
-  s.homepage    = "http://github.com/emilianodellacasa/ruby-asterisk"
-  s.summary     = %q{Asterisk Manager Interface in Ruby}
-  s.description = %q{Add support to your ruby or rails projects to Asterisk Manager Interface (AMI)}
+  s.authors     = ['Emiliano Della Casa']
+  s.email       = ['emiliano.dellacasa@gmail.com']
+  s.homepage    = 'http://github.com/emilianodellacasa/ruby-asterisk'
+  s.summary     = 'Asterisk Manager Interface in Ruby'
+  s.description = 'Add support to your ruby or rails projects to Asterisk Manager Interface (AMI)'
   s.licenses    = ['MIT']
+  s.required_ruby_version = '>= 3.1'
 
   s.files         = `git ls-files`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.require_paths = ['lib']
 
-  s.add_dependency "net-telnet"
-  s.add_development_dependency "rake"
+  s.add_dependency 'net-telnet'
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop-performance'
   s.add_development_dependency 'simplecov'
+  s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/ruby-asterisk/request_spec.rb
+++ b/spec/ruby-asterisk/request_spec.rb
@@ -1,17 +1,16 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 describe RubyAsterisk::Request do
-
-  describe "of type Originate" do
-    it "should set a Variable option if set" do
-      request = RubyAsterisk::Request.new("Originate",{"Channel" => "1234", "Context" => "test", "Exten" => "1", "Priority" => "1", "Callerid" => "1234", "Timeout" => "30000", "Variable" => "var1=15"  })
+  describe 'of type Originate' do
+    it 'should set a Variable option if set' do
+      request = RubyAsterisk::Request.new('Originate', { 'Channel' => '1234', 'Context' => 'test', 'Exten' => '1', 'Priority' => '1', 'Callerid' => '1234', 'Timeout' => '30000', 'Variable' => 'var1=15' })
       request.commands.include?("Variable: var1=15\r\n").should_not be_nil
     end
 
-    it "should not set a Variable option if not set" do
-      request = RubyAsterisk::Request.new("Originate",{"Channel" => "1234", "Context" => "test", "Exten" => "1", "Priority" => "1", "Callerid" => "1234", "Timeout" => "30000", "Variable" => nil  })
-      request.commands.include?("Variable: var=15").should==false
+    it 'should not set a Variable option if not set' do
+      request = RubyAsterisk::Request.new('Originate', { 'Channel' => '1234', 'Context' => 'test', 'Exten' => '1', 'Priority' => '1', 'Callerid' => '1234', 'Timeout' => '30000', 'Variable' => nil })
+      request.commands.include?('Variable: var=15').should == false
     end
   end
 end
-

--- a/spec/ruby-asterisk/response_spec.rb
+++ b/spec/ruby-asterisk/response_spec.rb
@@ -1,7 +1,7 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 describe RubyAsterisk::Response do
-
   def sip_peers_response
     "Response: Success
      Message: Peer status list will follow
@@ -96,90 +96,89 @@ describe RubyAsterisk::Response do
     Status: 0\n\n"
   end
 
-  describe ".new" do
-
-    describe "receiving a Core Show Channels request" do
-      it "should parse correctly data coming from Asterisk about channels" do
-        @response = RubyAsterisk::Response.new("CoreShowChannels", [core_show_channels_response])
+  describe '.new' do
+    describe 'receiving a Core Show Channels request' do
+      it 'should parse correctly data coming from Asterisk about channels' do
+        @response = RubyAsterisk::Response.new('CoreShowChannels', [core_show_channels_response])
         @response.data[:channels].should_not be_empty
       end
 
-      it "should correctly fill the fields" do
-        @response = RubyAsterisk::Response.new("CoreShowChannels", [core_show_channels_response])
-        @response.data[:channels][0]["CallerIDnum"].should eq("123456")
+      it 'should correctly fill the fields' do
+        @response = RubyAsterisk::Response.new('CoreShowChannels', [core_show_channels_response])
+        @response.data[:channels][0]['CallerIDnum'].should eq('123456')
       end
 
-      it "should have no channels if answer is empty" do
-        @response = RubyAsterisk::Response.new("CoreShowChannels", [empty_core_show_channels_response])
+      it 'should have no channels if answer is empty' do
+        @response = RubyAsterisk::Response.new('CoreShowChannels', [empty_core_show_channels_response])
         @response.data[:channels].count.should eq(0)
       end
     end
 
-    describe "receiving a Parked Calls request" do
-      it "should parse correctly data coming from Asterisk about calls" do
-        @response = RubyAsterisk::Response.new("ParkedCalls", [parked_calls_response])
+    describe 'receiving a Parked Calls request' do
+      it 'should parse correctly data coming from Asterisk about calls' do
+        @response = RubyAsterisk::Response.new('ParkedCalls', [parked_calls_response])
         @response.data[:calls].should_not be_empty
       end
 
-      it "should correctly fill the fields" do
-        @response = RubyAsterisk::Response.new("ParkedCalls",[parked_calls_response])
-        @response.data[:calls][0]["Exten"].should eq("701")
+      it 'should correctly fill the fields' do
+        @response = RubyAsterisk::Response.new('ParkedCalls', [parked_calls_response])
+        @response.data[:calls][0]['Exten'].should eq('701')
       end
     end
 
-    describe "receiving a Originate request" do
-      it "should parse correctly data coming from Asterisk about the call" do
-        @response = RubyAsterisk::Response.new("Originate",[originate_response])
+    describe 'receiving a Originate request' do
+      it 'should parse correctly data coming from Asterisk about the call' do
+        @response = RubyAsterisk::Response.new('Originate', [originate_response])
         @response.data[:dial].should_not be_empty
       end
 
-      it "should correctly fill the fields" do
-        @response = RubyAsterisk::Response.new("Originate",[originate_response])
-        @response.data[:dial][0]["UniqueID"].should eq("1335457364.68")
+      it 'should correctly fill the fields' do
+        @response = RubyAsterisk::Response.new('Originate', [originate_response])
+        @response.data[:dial][0]['UniqueID'].should eq('1335457364.68')
       end
 
-      it "should have a field with original raw response" do
-        @response = RubyAsterisk::Response.new("Originate",[originate_response])
+      it 'should have a field with original raw response' do
+        @response = RubyAsterisk::Response.new('Originate', [originate_response])
         @response.raw_response.join.should eq(originate_response)
       end
     end
 
-    describe "receiving a MeetMeList request" do
-      it "should parse correctly data coming from Asterisk about the conference room" do
-        @response = RubyAsterisk::Response.new("MeetMeList",[meet_me_list_response])
+    describe 'receiving a MeetMeList request' do
+      it 'should parse correctly data coming from Asterisk about the conference room' do
+        @response = RubyAsterisk::Response.new('MeetMeList', [meet_me_list_response])
         @response.data[:rooms].should_not be_empty
       end
 
-      it "should correctly fill the fields" do
-        @response = RubyAsterisk::Response.new("MeetMeList",[meet_me_list_response])
-        @response.data[:rooms][0]["Conference"].should eq("1234")
+      it 'should correctly fill the fields' do
+        @response = RubyAsterisk::Response.new('MeetMeList', [meet_me_list_response])
+        @response.data[:rooms][0]['Conference'].should eq('1234')
       end
     end
 
-    describe "receiving a ExtensionState request" do
-      it "should parse correctly data coming from Asterisk about the state of the extension" do
-        @response = RubyAsterisk::Response.new("ExtensionState", [extension_state_response])
+    describe 'receiving a ExtensionState request' do
+      it 'should parse correctly data coming from Asterisk about the state of the extension' do
+        @response = RubyAsterisk::Response.new('ExtensionState', [extension_state_response])
         @response.data[:hints].should_not be_empty
       end
 
-      it "should correctly fill the fields" do
-        @response = RubyAsterisk::Response.new("ExtensionState", [extension_state_response])
-        @response.data[:hints][0]["Status"].should eq("0")
-        @response.data[:hints][0]["DescriptiveStatus"].should eq("Idle")
+      it 'should correctly fill the fields' do
+        @response = RubyAsterisk::Response.new('ExtensionState', [extension_state_response])
+        @response.data[:hints][0]['Status'].should eq('0')
+        @response.data[:hints][0]['DescriptiveStatus'].should eq('Idle')
       end
     end
   end
 
-  describe "receiving a SIPPeers request" do
-    it "should parse correctly data coming from Asterisk abous sip peers" do
-      @response = RubyAsterisk::Response.new("SIPpeers",[sip_peers_response])
+  describe 'receiving a SIPPeers request' do
+    it 'should parse correctly data coming from Asterisk abous sip peers' do
+      @response = RubyAsterisk::Response.new('SIPpeers', [sip_peers_response])
       @response.data[:peers].should_not be_empty
     end
 
-    it "should correctly fill the fields" do
-      @response = RubyAsterisk::Response.new("SIPpeers",[sip_peers_response])
-      @response.data[:peers][0]["ObjectName"].should eq("9915057")
-      @response.data[:peers][0]["IPport"].should eq("5060")
+    it 'should correctly fill the fields' do
+      @response = RubyAsterisk::Response.new('SIPpeers', [sip_peers_response])
+      @response.data[:peers][0]['ObjectName'].should eq('9915057')
+      @response.data[:peers][0]['IPport'].should eq('5060')
     end
   end
 end

--- a/spec/ruby-asterisk/ruby_asterisk_spec.rb
+++ b/spec/ruby-asterisk/ruby_asterisk_spec.rb
@@ -1,192 +1,191 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 describe RubyAsterisk do
-
-  def mock_request(stubs={})
+  def mock_request(stubs = {})
     (@mock_request ||= mock_model(RubyAsterisk::Request).as_null_object).tap do |request|
       request.stub(stubs) unless stubs.empty?
     end
   end
 
   before :each do
-    @session = RubyAsterisk::AMI.new("127.0.0.1",5038)
+    @session = RubyAsterisk::AMI.new('127.0.0.1', 5038)
   end
 
   after :each do
     @session.disconnect
   end
 
-  describe ".new" do
-    it "initialize session with host" do
-      @session.host.should eq("127.0.0.1")
+  describe '.new' do
+    it 'initialize session with host' do
+      @session.host.should eq('127.0.0.1')
     end
 
-    it "initialize session with host" do
+    it 'initialize session with host' do
       @session.port.should eq(5038)
     end
 
-    it "should start the session as disconnected" do
+    it 'should start the session as disconnected' do
       @session.connected.should be false
     end
-  end 
+  end
 
-  describe ".connect" do
-    it "should return true if everything is ok" do
+  describe '.connect' do
+    it 'should return true if everything is ok' do
       @session.connect.should be true
     end
 
-    it "should return false if everything if something went wrong" do
+    it 'should return false if everything if something went wrong' do
       @session.port = 666
       @session.connect.should be false
       @session.port = 5038
     end
 
-    it "should change state to session as connected" do
+    it 'should change state to session as connected' do
       @session.connect
       @session.connected.should be true
     end
   end
 
-  describe ".disconnect" do
-    it "should return true if everything is ok" do
+  describe '.disconnect' do
+    it 'should return true if everything is ok' do
       @session.disconnect.should be true
     end
 
-    it "should change state to session as disconnected" do
+    it 'should change state to session as disconnected' do
       @session.disconnect
-@session.connected.should be false
+      @session.connected.should be false
     end
   end
 
-  describe ".login" do
-    it "should return a response object" do
-      @session.login("mark","mysecret").should be_kind_of(RubyAsterisk::Response)
+  describe '.login' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret').should be_kind_of(RubyAsterisk::Response)
     end
 
-    it "should return a response with type Login" do
-      @session.login("mark","mysecret").type.should eq("Login")
+    it 'should return a response with type Login' do
+      @session.login('mark', 'mysecret').type.should eq('Login')
     end
 
-    describe "if everything is ok" do
-      it "should return a successfull response" do
-        @session.login("mark","mysecret").success.should be true
+    describe 'if everything is ok' do
+      it 'should return a successfull response' do
+        @session.login('mark', 'mysecret').success.should be true
       end
 
-      it "should fill the ActionID" do
-        @session.login("mark","mysecret").action_id.should_not be_nil
+      it 'should fill the ActionID' do
+        @session.login('mark', 'mysecret').action_id.should_not be_nil
       end
 
-      it "should fill the Message" do
-        @session.login("mark","mysecret").message.should_not be_nil
+      it 'should fill the Message' do
+        @session.login('mark', 'mysecret').message.should_not be_nil
       end
     end
 
-    describe "if credentials are wrong" do
-      it "should not return a successfull response" do
-        @session.login("mark","wrong").success.should be false
+    describe 'if credentials are wrong' do
+      it 'should not return a successfull response' do
+        @session.login('mark', 'wrong').success.should be false
       end
     end
   end
 
-  describe ".core_show_channels" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
+  describe '.core_show_channels' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
       @session.core_show_channels.should be_kind_of(RubyAsterisk::Response)
     end
 
-    it "should contain additional data about channels" do
-      @session.login("mark","mysecret")
+    it 'should contain additional data about channels' do
+      @session.login('mark', 'mysecret')
       @session.core_show_channels.data[:channels].should_not be_nil
-    end 
+    end
   end
 
-  describe ".parked_calls" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
+  describe '.parked_calls' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
       @session.parked_calls.should be_kind_of(RubyAsterisk::Response)
     end
 
-    it "should contain additional data about parked calls" do
-      @session.login("mark","mysecret")
+    it 'should contain additional data about parked calls' do
+      @session.login('mark', 'mysecret')
       @session.parked_calls.data[:calls].should_not be_nil
     end
   end
 
-  describe ".originate" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
-      @session.originate("SIP/9100","OUTGOING","123456","1","queue=SIP/1000&SIP/1001").should be_kind_of(RubyAsterisk::Response)
+  describe '.originate' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
+      @session.originate('SIP/9100', 'OUTGOING', '123456', '1', 'queue=SIP/1000&SIP/1001').should be_kind_of(RubyAsterisk::Response)
     end
   end
 
-  describe ".command" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
-      @session.command("meetme list").should be_kind_of(RubyAsterisk::Response)
+  describe '.command' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
+      @session.command('meetme list').should be_kind_of(RubyAsterisk::Response)
     end
   end
 
-  describe ".meet_me_list" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
+  describe '.meet_me_list' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
       @session.meet_me_list.should be_kind_of(RubyAsterisk::Response)
     end
   end
 
-  describe ".extension_state" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
-      @session.extension_state("9100","HINT").should be_kind_of(RubyAsterisk::Response)
+  describe '.extension_state' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
+      @session.extension_state('9100', 'HINT').should be_kind_of(RubyAsterisk::Response)
     end
   end
 
-  describe ".sip_peers" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
+  describe '.sip_peers' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
       @session.sip_peers.should be_kind_of(RubyAsterisk::Response)
     end
   end
 
-  describe ".wait_event" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
+  describe '.wait_event' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
       @session.wait_event(1).should be_kind_of(RubyAsterisk::Response)
     end
   end
 
-  describe ".monitor" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
-      @session.monitor("SIP/9100").should be_kind_of(RubyAsterisk::Response)
+  describe '.monitor' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
+      @session.monitor('SIP/9100').should be_kind_of(RubyAsterisk::Response)
     end
   end
 
-  describe ".stop_monitor" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
-      @session.stop_monitor("SIP/9100").should be_kind_of(RubyAsterisk::Response)
+  describe '.stop_monitor' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
+      @session.stop_monitor('SIP/9100').should be_kind_of(RubyAsterisk::Response)
     end
   end
 
-  describe ".pause_monitor" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
-      @session.pause_monitor("SIP/9100").should be_kind_of(RubyAsterisk::Response)
+  describe '.pause_monitor' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
+      @session.pause_monitor('SIP/9100').should be_kind_of(RubyAsterisk::Response)
     end
   end
 
-  describe ".unpause_monitor" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
-      @session.unpause_monitor("SIP/9100").should be_kind_of(RubyAsterisk::Response)
+  describe '.unpause_monitor' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
+      @session.unpause_monitor('SIP/9100').should be_kind_of(RubyAsterisk::Response)
     end
   end
 
-  describe ".change_monitor" do
-    it "should return a response object" do
-      @session.login("mark","mysecret")
-      @session.change_monitor("SIP/9100","first-sip-9100").should be_kind_of(RubyAsterisk::Response)
+  describe '.change_monitor' do
+    it 'should return a response object' do
+      @session.login('mark', 'mysecret')
+      @session.change_monitor('SIP/9100', 'first-sip-9100').should be_kind_of(RubyAsterisk::Response)
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start
 require 'rubygems'
@@ -25,15 +27,15 @@ RSpec.configure do |config|
       full_command = @commands.join
       @commands = [] # reset for next command
 
-      response = if full_command.include?("Action: Login")
-        if full_command.include?("Secret: mysecret")
-          "Response: Success\nActionID: 123\nMessage: Authentication accepted\n\n"
-        elsif full_command.include?("Secret: wrong")
-          "Response: Error\nActionID: 123\nMessage: Authentication failed\n\n"
-        end
-      else
-        "Response: Success\nActionID: 123\n\n"
-      end
+      response = if full_command.include?('Action: Login')
+                   if full_command.include?('Secret: mysecret')
+                     "Response: Success\nActionID: 123\nMessage: Authentication accepted\n\n"
+                   elsif full_command.include?('Secret: wrong')
+                     "Response: Error\nActionID: 123\nMessage: Authentication failed\n\n"
+                   end
+                 else
+                   "Response: Success\nActionID: 123\n\n"
+                 end
       block.call(response) if response
     end
   end


### PR DESCRIPTION
## Summary
- Add rubocop and rubocop-performance as development dependencies
- Create .rubocop.yml with frozen_string_literal and single quotes enforcement
- Add frozen_string_literal: true to all Ruby files for Ractor compatibility
- Fix code violations and add Linting job to CI pipeline

## Changes
- **Gemspec**: Added rubocop, rubocop-performance, and required_ruby_version >= 3.1
- **Rubocop config**: Enabled Style/FrozenStringLiteralComment, Style/StringLiterals (single quotes), excluded legacy AMI class from metrics
- **Code fixes**: Changed rescue Exception to rescue StandardError, removed duplicate queue_pause method, fixed frozen string mutation
- **CI**: Added Linting job that runs before tests

## Test plan
- [x] bundle exec rubocop returns exit code 0
- [x] All 45 tests pass
- [x] All Ruby files have frozen string literal comment

Generated with Claude Code