### PR TITLE
Issue #44 - Dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,10 @@ Layout/LineLength:
 Gemspec/DevelopmentDependencies:
   Enabled: false
 
+# We explicitly use add_runtime_dependency for clarity about dependency types
+Gemspec/AddRuntimeDependency:
+  Enabled: false
+
 # Exclude legacy AMI class from parameter list checks until refactored
 Metrics/ParameterLists:
   Exclude:

--- a/lib/ruby-asterisk/parsing_constants.rb
+++ b/lib/ruby-asterisk/parsing_constants.rb
@@ -96,5 +96,5 @@ module RubyAsterisk
       search_for: 'Response: Success',
       stop_with: nil
     }
-  }.freeze
+  }.each_value(&:freeze).freeze
 end

--- a/ruby-asterisk.gemspec
+++ b/ruby-asterisk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'net-telnet'
+  s.add_runtime_dependency 'net-telnet'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'


### PR DESCRIPTION
## Summary                                                                                                                                 
  - Explicitly declare `net-telnet` as `add_runtime_dependency` in the gemspec (was `add_dependency`)                                        
  - Deep-freeze inner hashes of `PARSE_DATA` constant to ensure Ractor shareability
  - Disable `Gemspec/AddRuntimeDependency` Rubocop cop to allow the explicit dependency form                                                 
                                                            
  ## Ractor Risk Report                                                                                                                      
                                                            
  ### Runtime Dependencies

  | Dependency | Native Extensions | Global State | Ractor Risk |
  |---|---|---|---|
  | **net-telnet** (0.2.0) | None (pure Ruby) | `$ERROR_INFO` (thread-local) | **Medium** |

  `net-telnet` has not been updated since 2018 and is not Ractor-aware. Socket objects cannot be shared across Ractors. Mitigation: each
  Ractor must create its own `AMI` instance.

  ### Internal Code

  | Item | Issue | Status |
  |---|---|---|
  | `PARSE_DATA` inner hashes | Were mutable (only outer hash frozen) | **Fixed** |
  | `DESCRIPTIVE_STATUS` | Frozen hash, frozen string values | Safe |
  | `Rami::VERSION` | Frozen string (`frozen_string_literal: true`) | Safe |
  | Class variables (`@@`) | None found | Safe |
  | Global variables (`$`) | None found | Safe |
  | `frozen_string_literal: true` | Present in all source files | Safe |

  ### Development Dependencies

  `rake`, `rspec`, `rubocop`, `rubocop-performance`, `simplecov` — **N/A** (not shipped at runtime).

  ## Test plan
  - [x] `bundle exec rake spec` — 45 examples, 0 failures
  - [x] `bundle exec rubocop` — 0 offenses

  Closes #44
