### PR TITLE
Issue #45 - Immutable Objects

### DIFF
--- a/lib/ruby-asterisk.rb
+++ b/lib/ruby-asterisk.rb
@@ -3,6 +3,7 @@
 require 'ruby-asterisk/version'
 require 'ruby-asterisk/request'
 require 'ruby-asterisk/response'
+require 'ruby-asterisk/response_builder'
 require 'net/telnet'
 
 module RubyAsterisk
@@ -218,14 +219,18 @@ module RubyAsterisk
 
     def execute(command, options = {})
       request = Request.new(command, options)
-      request.commands.each do |command|
-        @session.write(command)
+      request.commands.each do |cmd|
+        @session.write(cmd)
       end
+      response_data = +''
       @session.waitfor('Match' => /ActionID: #{request.action_id}.*?\n\n/m, 'Timeout' => @timeout,
                        'Waittime' => @wait_time) do |data|
-        request.response_data << data.to_s
+        response_data << data.to_s
       end
-      Response.new(command, request.response_data)
+      builder = ResponseBuilder.new
+      builder.type = command
+      builder.raw_response = response_data
+      builder.build
     end
   end
 end

--- a/lib/ruby-asterisk/request.rb
+++ b/lib/ruby-asterisk/request.rb
@@ -6,13 +6,13 @@ module RubyAsterisk
   # Class responsible of building commands structure
   #
   class Request
-    attr_accessor :action, :action_id, :parameters, :response_data
+    attr_reader :action, :action_id, :parameters
 
     def initialize(action, parameters = {})
-      self.action = action
-      self.action_id = Request.generate_action_id
-      self.parameters = parameters
-      self.response_data = +''
+      @action = action.freeze
+      @action_id = Request.generate_action_id.freeze
+      @parameters = deep_freeze_hash(parameters)
+      freeze
     end
 
     def commands
@@ -26,6 +26,14 @@ module RubyAsterisk
 
     def self.generate_action_id
       Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond).to_s(36)
+    end
+
+    private
+
+    def deep_freeze_hash(hash)
+      hash.each_with_object({}) do |(key, value), result|
+        result[key.freeze] = value.freeze
+      end.freeze
     end
   end
 end

--- a/lib/ruby-asterisk/response.rb
+++ b/lib/ruby-asterisk/response.rb
@@ -8,14 +8,16 @@ module RubyAsterisk
   # Class for response coming from Asterisk
   #
   class Response
-    attr_accessor :type, :action_id, :message, :data, :raw_response
+    attr_reader :type, :action_id, :message, :data, :raw_response
 
     def initialize(type, response)
-      self.raw_response = [response].flatten
-      self.type = type
-      self.action_id = _parse_action_id
-      self.message = _parse_message
-      self.data = _parse_response
+      @raw_response = [response].flatten
+      @type = type
+      @action_id = _parse_action_id
+      @message = _parse_message
+      @data = _parse_response
+      deep_freeze
+      freeze
     end
 
     def success
@@ -43,6 +45,29 @@ module RubyAsterisk
 
     def _parse_response
       ResponseParser.parse(raw_response, type)
+    end
+
+    private
+
+    def deep_freeze
+      @type.freeze
+      @action_id.freeze
+      @message.freeze
+      deep_freeze_value(@raw_response)
+      deep_freeze_value(@data)
+    end
+
+    def deep_freeze_value(obj)
+      case obj
+      when Hash
+        obj.each do |key, value|
+          key.freeze
+          deep_freeze_value(value)
+        end
+      when Array
+        obj.each { |element| deep_freeze_value(element) }
+      end
+      obj.freeze
     end
   end
 end

--- a/lib/ruby-asterisk/response_builder.rb
+++ b/lib/ruby-asterisk/response_builder.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  ##
+  #
+  # Mutable builder that produces an immutable Response
+  #
+  class ResponseBuilder
+    attr_accessor :type, :raw_response
+
+    def build
+      raise ArgumentError, 'type is required' if @type.nil?
+      raise ArgumentError, 'raw_response is required' if @raw_response.nil?
+
+      Response.new(@type, @raw_response)
+    end
+  end
+end

--- a/spec/ruby-asterisk/immutability_spec.rb
+++ b/spec/ruby-asterisk/immutability_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Immutability for Ractor safety' do
+  describe RubyAsterisk::Request do
+    subject { RubyAsterisk::Request.new('Originate', { 'Channel' => '1234', 'Context' => 'test' }) }
+
+    it 'is frozen' do
+      subject.should be_frozen
+    end
+
+    it 'has a frozen action' do
+      subject.action.should be_frozen
+    end
+
+    it 'has a frozen action_id' do
+      subject.action_id.should be_frozen
+    end
+
+    it 'has a frozen parameters hash' do
+      subject.parameters.should be_frozen
+    end
+
+    it 'has frozen parameter keys and values' do
+      subject.parameters.each do |key, value|
+        key.should be_frozen
+        value.should be_frozen
+      end
+    end
+
+    it 'raises FrozenError when attempting to modify instance variables' do
+      -> { subject.instance_variable_set(:@action, 'Login') }.should raise_error(FrozenError)
+    end
+
+    it 'raises FrozenError when attempting to modify parameters' do
+      -> { subject.parameters['NewKey'] = 'val' }.should raise_error(FrozenError)
+    end
+
+    it 'does not expose writer methods' do
+      subject.respond_to?(:action=).should be false
+      subject.respond_to?(:parameters=).should be false
+      subject.respond_to?(:action_id=).should be false
+    end
+
+    it 'does not expose response_data' do
+      subject.respond_to?(:response_data).should be false
+      subject.respond_to?(:response_data=).should be false
+    end
+
+    it 'is Ractor-shareable' do
+      Ractor.shareable?(subject).should be true
+    end
+  end
+
+  describe RubyAsterisk::Response do
+    let(:raw_response) do
+      "Response: Success\nActionID: 123\nMessage: Authentication accepted\n\n"
+    end
+    subject { RubyAsterisk::Response.new('Login', raw_response) }
+
+    it 'is frozen' do
+      subject.should be_frozen
+    end
+
+    it 'has a frozen type' do
+      subject.type.should be_frozen
+    end
+
+    it 'has a frozen action_id' do
+      subject.action_id.should be_frozen
+    end
+
+    it 'has a frozen message' do
+      subject.message.should be_frozen
+    end
+
+    it 'has a frozen raw_response' do
+      subject.raw_response.should be_frozen
+      subject.raw_response.each do |element|
+        element.should be_frozen
+      end
+    end
+
+    it 'has frozen data' do
+      subject.data.should be_frozen
+    end
+
+    it 'raises FrozenError when attempting to modify instance variables' do
+      -> { subject.instance_variable_set(:@type, 'Other') }.should raise_error(FrozenError)
+    end
+
+    it 'does not expose writer methods' do
+      subject.respond_to?(:type=).should be false
+      subject.respond_to?(:action_id=).should be false
+      subject.respond_to?(:message=).should be false
+      subject.respond_to?(:data=).should be false
+      subject.respond_to?(:raw_response=).should be false
+    end
+
+    it 'is Ractor-shareable' do
+      Ractor.shareable?(subject).should be true
+    end
+
+    context 'with parsed data containing nested structures' do
+      let(:raw_response) do
+        "Event: CoreShowChannel\nActionID: 839\nChannel: SIP/test\nCallerIDnum: 123\n\n" \
+          "Event: CoreShowChannelsComplete\nActionID: 839\n\n"
+      end
+      subject { RubyAsterisk::Response.new('CoreShowChannels', raw_response) }
+
+      it 'has deeply frozen data structures' do
+        subject.data.should be_frozen
+        subject.data[:channels].should be_frozen
+        subject.data[:channels].each do |channel|
+          channel.should be_frozen
+          channel.each do |key, value|
+            key.should be_frozen
+            value.should be_frozen
+          end
+        end
+      end
+
+      it 'raises FrozenError when attempting to modify nested data' do
+        -> { subject.data[:channels] << {} }.should raise_error(FrozenError)
+      end
+    end
+  end
+
+  describe RubyAsterisk::ResponseBuilder do
+    it 'builds a frozen Response' do
+      builder = RubyAsterisk::ResponseBuilder.new
+      builder.type = 'Login'
+      builder.raw_response = "Response: Success\nActionID: 123\n\n"
+      response = builder.build
+      response.should be_frozen
+    end
+
+    it 'raises ArgumentError when type is missing' do
+      builder = RubyAsterisk::ResponseBuilder.new
+      builder.raw_response = "Response: Success\n\n"
+      -> { builder.build }.should raise_error(ArgumentError, 'type is required')
+    end
+
+    it 'raises ArgumentError when raw_response is missing' do
+      builder = RubyAsterisk::ResponseBuilder.new
+      builder.type = 'Login'
+      -> { builder.build }.should raise_error(ArgumentError, 'raw_response is required')
+    end
+
+    it 'is not frozen itself' do
+      builder = RubyAsterisk::ResponseBuilder.new
+      builder.should_not be_frozen
+    end
+  end
+end


### PR DESCRIPTION
### Summary                                                                                                                                
                                                            
  - Refactor `Request` and `Response` classes to be deeply frozen and immutable after construction, making them safe for sharing across Ruby 
  Ractors                                                                                                                                    
  - Extract response data accumulation from `Request` into a local variable in `AMI#execute`, where it belongs as an I/O concern
  - Introduce `ResponseBuilder` as a mutable-to-immutable boundary for constructing `Response` objects

  ### Motivation

  The upcoming architecture introduces a Socket Reader Ractor that creates response objects and passes them to the Main Ractor. Ruby Ractors
  only allow moving or sharing **deeply frozen** objects. Previously, both `Request` and `Response` used `attr_accessor` (exposing setters)
  and held mutable internal state, making them incompatible with Ractor sharing.

  Key insight: neither class is actually built incrementally — all attributes are set in the constructor. The only post-construction mutation
   was `Request#response_data` being accumulated in `AMI#execute`, which is an I/O concern that doesn't belong on Request.

  ### Changes

  | File | Description |
  |------|-------------|
  | `lib/ruby-asterisk/request.rb` | `attr_accessor` → `attr_reader`, removed `response_data`, deep-freeze all attributes, `freeze` at end of `initialize` |
  | `lib/ruby-asterisk/response.rb` | `attr_accessor` → `attr_reader`, recursive `deep_freeze` of all nested data structures, `freeze` at end of `initialize` |
  | `lib/ruby-asterisk/response_builder.rb` | New mutable builder that validates inputs and produces an immutable `Response` |
  | `lib/ruby-asterisk.rb` | Use local `response_data` variable instead of `request.response_data`, construct response via `ResponseBuilder`, fix variable shadowing (`command` → `cmd`) |
  | `spec/ruby-asterisk/immutability_spec.rb` | 22 new tests covering frozen state, deep-freeze of nested structures, `FrozenError` on mutation, no writer methods, and `Ractor.shareable?` verification |

  ### Test plan

  - [ ] All 70 existing + new specs pass (`bundle exec rake spec`)
  - [ ] Rubocop reports no offenses on changed files
  - [ ] `Ractor.shareable?` returns `true` for both `Request` and `Response` instances