### PR TITLE
Refactor: Extract command modules from AMI::Client (Issue #47)

### DIFF
--- a/lib/ruby-asterisk/ami/client.rb
+++ b/lib/ruby-asterisk/ami/client.rb
@@ -4,6 +4,14 @@ require 'ruby-asterisk/version'
 require 'ruby-asterisk/request'
 require 'ruby-asterisk/response'
 require 'ruby-asterisk/response_builder'
+require 'ruby-asterisk/ami/commands/system'
+require 'ruby-asterisk/ami/commands/channel'
+require 'ruby-asterisk/ami/commands/conference'
+require 'ruby-asterisk/ami/commands/extension'
+require 'ruby-asterisk/ami/commands/queue'
+require 'ruby-asterisk/ami/commands/mailbox'
+require 'ruby-asterisk/ami/commands/sip'
+require 'ruby-asterisk/ami/commands/monitor'
 require 'net/telnet'
 
 module RubyAsterisk
@@ -13,6 +21,15 @@ module RubyAsterisk
     # Ruby-asterisk main classes
     #
     class Client
+      include Commands::System
+      include Commands::Channel
+      include Commands::Conference
+      include Commands::Extension
+      include Commands::Queue
+      include Commands::Mailbox
+      include Commands::Sip
+      include Commands::Monitor
+
       attr_accessor :host, :port, :connected, :timeout, :wait_time
 
       def initialize(host:, port:)
@@ -38,183 +55,6 @@ module RubyAsterisk
       rescue StandardError => e
         puts e
         false
-      end
-
-      def login(username:, secret:)
-        connect unless connected
-        execute 'Login', { 'Username' => username, 'Secret' => secret, 'Event' => 'On' }
-      end
-
-      def logoff
-        execute 'Logoff'
-      end
-
-      def command(command)
-        execute 'Command', { 'Command' => command }
-      end
-
-      def core_show_channels
-        execute 'CoreShowChannels'
-      end
-
-      def meet_me_list
-        execute 'MeetMeList'
-      end
-
-      def confbridges
-        execute 'ConfbridgeListRooms'
-      end
-
-      def confbridge(conference)
-        execute 'ConfbridgeList', { 'Conference' => conference }
-      end
-
-      def confbridge_mute(conference:, channel:)
-        execute 'ConfbridgeMute', { 'Conference' => conference, 'Channel' => channel }
-      end
-
-      def confbridge_unmute(conference:, channel:)
-        execute 'ConfbridgeUnmute', { 'Conference' => conference, 'Channel' => channel }
-      end
-
-      def confbridge_kick(conference:, channel:)
-        execute 'ConfbridgeKick', { 'Conference' => conference, 'Channel' => channel }
-      end
-
-      def parked_calls
-        execute 'ParkedCalls'
-      end
-
-      def extension_state(exten:, context:, action_id: nil)
-        execute 'ExtensionState', { 'Exten' => exten, 'Context' => context, 'ActionID' => action_id }
-      end
-
-      def device_state_list
-        execute 'DeviceStateList'
-      end
-
-      def skinny_devices
-        execute 'SKINNYdevices'
-      end
-
-      def skinny_lines
-        execute 'SKINNYlines'
-      end
-
-      def status(channel: nil, action_id: nil)
-        execute 'Status', { 'Channel' => channel, 'ActionID' => action_id }
-      end
-
-      def originate(channel, context, callee, priority, variable: nil, caller_id: nil, timeout: 30_000, async: nil)
-        @timeout = [@timeout, timeout / 1000].max
-        execute 'Originate',
-                { 'Channel' => channel, 'Context' => context, 'Exten' => callee, 'Priority' => priority,
-                  'CallerID' => caller_id || channel, 'Timeout' => timeout.to_s, 'Variable' => variable,
-                  'Async' => async }
-      end
-
-      def originate_app(channel:, application:, data:, async:)
-        execute 'Originate',
-                { 'Channel' => channel, 'Application' => application, 'Data' => data, 'Timeout' => '30000',
-                  'Async' => async }
-      end
-
-      def channels
-        execute 'Command', { 'Command' => 'show channels' }
-      end
-
-      def redirect(channel, context, callee, priority, variable: nil, caller_id: nil, timeout: 30_000)
-        @timeout = [@timeout, timeout / 1000].max
-        execute 'Redirect',
-                { 'Channel' => channel, 'Context' => context, 'Exten' => callee, 'Priority' => priority,
-                  'CallerID' => caller_id || channel, 'Timeout' => timeout.to_s, 'Variable' => variable }
-      end
-
-      def queues
-        execute 'Queues', {}
-      end
-
-      def queue_add(queue, interface, penalty: 2, paused: false, member_name: '')
-        execute 'QueueAdd',
-                { 'Queue' => queue, 'Interface' => interface, 'Penalty' => penalty, 'Paused' => paused,
-                  'MemberName' => member_name }
-      end
-
-      def queue_remove(queue:, interface:)
-        execute 'QueueRemove', { 'Queue' => queue, 'Interface' => interface }
-      end
-
-      def queue_status
-        execute 'QueueStatus'
-      end
-
-      def queue_summary(queue)
-        execute 'QueueSummary', { 'Queue' => queue }
-      end
-
-      def mailbox_status(mailbox:, context: 'default')
-        execute 'MailboxStatus', { 'Mailbox' => "#{mailbox}@#{context}" }
-      end
-
-      def mailbox_count(mailbox:, context: 'default')
-        execute 'MailboxCount', { 'Mailbox' => "#{mailbox}@#{context}" }
-      end
-
-      def queue_pause(interface:, paused:, queue:, reason: 'none')
-        execute 'QueuePause', { 'Interface' => interface, 'Paused' => paused, 'Queue' => queue, 'Reason' => reason }
-      end
-
-      def ping
-        execute 'Ping'
-      end
-
-      def event_mask(event_mask = 'off')
-        execute 'Events', { 'EventMask' => event_mask }
-      end
-
-      def sip_peers
-        execute 'SIPpeers'
-      end
-
-      def sip_show_peer(peer)
-        execute 'SIPshowpeer', { 'Peer' => peer }
-      end
-
-      def hangup(channel)
-        execute 'Hangup', { 'Channel' => channel }
-      end
-
-      def atxfer(channel:, exten:, context:, priority: '1')
-        execute 'Atxfer', { 'Channel' => channel, 'Exten' => exten.to_s, 'Context' => context, 'Priority' => priority }
-      end
-
-      def wait_event(timeout: -1)
-        @timeout = [@timeout, timeout].max
-        execute 'WaitEvent', { 'Timeout' => timeout }
-      end
-
-      def monitor(channel, mix: false, file: nil, format: 'wav')
-        execute 'Monitor', { 'Channel' => channel, 'File' => file, 'Mix' => mix, 'Format' => format }
-      end
-
-      def stop_monitor(channel)
-        execute 'StopMonitor', { 'Channel' => channel }
-      end
-
-      def pause_monitor(channel)
-        execute 'PauseMonitor', { 'Channel' => channel }
-      end
-
-      def unpause_monitor(channel)
-        execute 'UnpauseMonitor', { 'Channel' => channel }
-      end
-
-      def change_monitor(channel:, file:)
-        execute 'ChangeMonitor', { 'Channel' => channel, 'File' => file }
-      end
-
-      def sip_show_registry
-        execute 'SIPshowregistry'
       end
 
       private

--- a/lib/ruby-asterisk/ami/commands/channel.rb
+++ b/lib/ruby-asterisk/ami/commands/channel.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module AMI
+    module Commands
+      module Channel
+        def core_show_channels
+          execute 'CoreShowChannels'
+        end
+
+        def status(channel: nil, action_id: nil)
+          execute 'Status', { 'Channel' => channel, 'ActionID' => action_id }
+        end
+
+        def originate(channel, context, callee, priority, variable: nil, caller_id: nil, timeout: 30_000, async: nil)
+          @timeout = [@timeout, timeout / 1000].max
+          execute 'Originate',
+                  { 'Channel' => channel, 'Context' => context, 'Exten' => callee, 'Priority' => priority,
+                    'CallerID' => caller_id || channel, 'Timeout' => timeout.to_s, 'Variable' => variable,
+                    'Async' => async }
+        end
+
+        def originate_app(channel:, application:, data:, async:)
+          execute 'Originate',
+                  { 'Channel' => channel, 'Application' => application, 'Data' => data, 'Timeout' => '30000',
+                    'Async' => async }
+        end
+
+        def channels
+          execute 'Command', { 'Command' => 'show channels' }
+        end
+
+        def redirect(channel, context, callee, priority, variable: nil, caller_id: nil, timeout: 30_000)
+          @timeout = [@timeout, timeout / 1000].max
+          execute 'Redirect',
+                  { 'Channel' => channel, 'Context' => context, 'Exten' => callee, 'Priority' => priority,
+                    'CallerID' => caller_id || channel, 'Timeout' => timeout.to_s, 'Variable' => variable }
+        end
+
+        def hangup(channel)
+          execute 'Hangup', { 'Channel' => channel }
+        end
+
+        def atxfer(channel:, exten:, context:, priority: '1')
+          execute 'Atxfer', { 'Channel' => channel, 'Exten' => exten.to_s, 'Context' => context, 'Priority' => priority }
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-asterisk/ami/commands/channel.rb
+++ b/lib/ruby-asterisk/ami/commands/channel.rb
@@ -3,6 +3,10 @@
 module RubyAsterisk
   module AMI
     module Commands
+      ##
+      #
+      # Channel commands
+      #
       module Channel
         def core_show_channels
           execute 'CoreShowChannels'
@@ -42,7 +46,8 @@ module RubyAsterisk
         end
 
         def atxfer(channel:, exten:, context:, priority: '1')
-          execute 'Atxfer', { 'Channel' => channel, 'Exten' => exten.to_s, 'Context' => context, 'Priority' => priority }
+          execute 'Atxfer',
+                  { 'Channel' => channel, 'Exten' => exten.to_s, 'Context' => context, 'Priority' => priority }
         end
       end
     end

--- a/lib/ruby-asterisk/ami/commands/conference.rb
+++ b/lib/ruby-asterisk/ami/commands/conference.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module AMI
+    module Commands
+      module Conference
+        def meet_me_list
+          execute 'MeetMeList'
+        end
+
+        def confbridges
+          execute 'ConfbridgeListRooms'
+        end
+
+        def confbridge(conference)
+          execute 'ConfbridgeList', { 'Conference' => conference }
+        end
+
+        def confbridge_mute(conference:, channel:)
+          execute 'ConfbridgeMute', { 'Conference' => conference, 'Channel' => channel }
+        end
+
+        def confbridge_unmute(conference:, channel:)
+          execute 'ConfbridgeUnmute', { 'Conference' => conference, 'Channel' => channel }
+        end
+
+        def confbridge_kick(conference:, channel:)
+          execute 'ConfbridgeKick', { 'Conference' => conference, 'Channel' => channel }
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-asterisk/ami/commands/conference.rb
+++ b/lib/ruby-asterisk/ami/commands/conference.rb
@@ -3,6 +3,10 @@
 module RubyAsterisk
   module AMI
     module Commands
+      ##
+      #
+      # Conference commands
+      #
       module Conference
         def meet_me_list
           execute 'MeetMeList'

--- a/lib/ruby-asterisk/ami/commands/extension.rb
+++ b/lib/ruby-asterisk/ami/commands/extension.rb
@@ -3,6 +3,10 @@
 module RubyAsterisk
   module AMI
     module Commands
+      ##
+      #
+      # Extension commands
+      #
       module Extension
         def parked_calls
           execute 'ParkedCalls'

--- a/lib/ruby-asterisk/ami/commands/extension.rb
+++ b/lib/ruby-asterisk/ami/commands/extension.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module AMI
+    module Commands
+      module Extension
+        def parked_calls
+          execute 'ParkedCalls'
+        end
+
+        def extension_state(exten:, context:, action_id: nil)
+          execute 'ExtensionState', { 'Exten' => exten, 'Context' => context, 'ActionID' => action_id }
+        end
+
+        def device_state_list
+          execute 'DeviceStateList'
+        end
+
+        def skinny_devices
+          execute 'SKINNYdevices'
+        end
+
+        def skinny_lines
+          execute 'SKINNYlines'
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-asterisk/ami/commands/mailbox.rb
+++ b/lib/ruby-asterisk/ami/commands/mailbox.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module AMI
+    module Commands
+      module Mailbox
+        def mailbox_status(mailbox:, context: 'default')
+          execute 'MailboxStatus', { 'Mailbox' => "#{mailbox}@#{context}" }
+        end
+
+        def mailbox_count(mailbox:, context: 'default')
+          execute 'MailboxCount', { 'Mailbox' => "#{mailbox}@#{context}" }
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-asterisk/ami/commands/mailbox.rb
+++ b/lib/ruby-asterisk/ami/commands/mailbox.rb
@@ -3,6 +3,10 @@
 module RubyAsterisk
   module AMI
     module Commands
+      ##
+      #
+      # Mailbox commands
+      #
       module Mailbox
         def mailbox_status(mailbox:, context: 'default')
           execute 'MailboxStatus', { 'Mailbox' => "#{mailbox}@#{context}" }

--- a/lib/ruby-asterisk/ami/commands/monitor.rb
+++ b/lib/ruby-asterisk/ami/commands/monitor.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module AMI
+    module Commands
+      module Monitor
+        def monitor(channel, mix: false, file: nil, format: 'wav')
+          execute 'Monitor', { 'Channel' => channel, 'File' => file, 'Mix' => mix, 'Format' => format }
+        end
+
+        def stop_monitor(channel)
+          execute 'StopMonitor', { 'Channel' => channel }
+        end
+
+        def pause_monitor(channel)
+          execute 'PauseMonitor', { 'Channel' => channel }
+        end
+
+        def unpause_monitor(channel)
+          execute 'UnpauseMonitor', { 'Channel' => channel }
+        end
+
+        def change_monitor(channel:, file:)
+          execute 'ChangeMonitor', { 'Channel' => channel, 'File' => file }
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-asterisk/ami/commands/monitor.rb
+++ b/lib/ruby-asterisk/ami/commands/monitor.rb
@@ -3,6 +3,10 @@
 module RubyAsterisk
   module AMI
     module Commands
+      ##
+      #
+      # Monitor commands
+      #
       module Monitor
         def monitor(channel, mix: false, file: nil, format: 'wav')
           execute 'Monitor', { 'Channel' => channel, 'File' => file, 'Mix' => mix, 'Format' => format }

--- a/lib/ruby-asterisk/ami/commands/queue.rb
+++ b/lib/ruby-asterisk/ami/commands/queue.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module AMI
+    module Commands
+      module Queue
+        def queues
+          execute 'Queues', {}
+        end
+
+        def queue_add(queue, interface, penalty: 2, paused: false, member_name: '')
+          execute 'QueueAdd',
+                  { 'Queue' => queue, 'Interface' => interface, 'Penalty' => penalty, 'Paused' => paused,
+                    'MemberName' => member_name }
+        end
+
+        def queue_remove(queue:, interface:)
+          execute 'QueueRemove', { 'Queue' => queue, 'Interface' => interface }
+        end
+
+        def queue_status
+          execute 'QueueStatus'
+        end
+
+        def queue_summary(queue)
+          execute 'QueueSummary', { 'Queue' => queue }
+        end
+
+        def queue_pause(interface:, paused:, queue:, reason: 'none')
+          execute 'QueuePause', { 'Interface' => interface, 'Paused' => paused, 'Queue' => queue, 'Reason' => reason }
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-asterisk/ami/commands/queue.rb
+++ b/lib/ruby-asterisk/ami/commands/queue.rb
@@ -3,6 +3,10 @@
 module RubyAsterisk
   module AMI
     module Commands
+      ##
+      #
+      # Queue commands
+      #
       module Queue
         def queues
           execute 'Queues', {}

--- a/lib/ruby-asterisk/ami/commands/sip.rb
+++ b/lib/ruby-asterisk/ami/commands/sip.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module AMI
+    module Commands
+      module Sip
+        def sip_peers
+          execute 'SIPpeers'
+        end
+
+        def sip_show_peer(peer)
+          execute 'SIPshowpeer', { 'Peer' => peer }
+        end
+
+        def sip_show_registry
+          execute 'SIPshowregistry'
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-asterisk/ami/commands/sip.rb
+++ b/lib/ruby-asterisk/ami/commands/sip.rb
@@ -3,6 +3,10 @@
 module RubyAsterisk
   module AMI
     module Commands
+      ##
+      #
+      # SIP commands
+      #
       module Sip
         def sip_peers
           execute 'SIPpeers'

--- a/lib/ruby-asterisk/ami/commands/system.rb
+++ b/lib/ruby-asterisk/ami/commands/system.rb
@@ -3,6 +3,10 @@
 module RubyAsterisk
   module AMI
     module Commands
+      ##
+      #
+      # System commands
+      #
       module System
         def login(username:, secret:)
           connect unless connected

--- a/lib/ruby-asterisk/ami/commands/system.rb
+++ b/lib/ruby-asterisk/ami/commands/system.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module AMI
+    module Commands
+      module System
+        def login(username:, secret:)
+          connect unless connected
+          execute 'Login', { 'Username' => username, 'Secret' => secret, 'Event' => 'On' }
+        end
+
+        def logoff
+          execute 'Logoff'
+        end
+
+        def ping
+          execute 'Ping'
+        end
+
+        def event_mask(event_mask = 'off')
+          execute 'Events', { 'EventMask' => event_mask }
+        end
+
+        def command(command)
+          execute 'Command', { 'Command' => command }
+        end
+
+        def wait_event(timeout: -1)
+          @timeout = [@timeout, timeout].max
+          execute 'WaitEvent', { 'Timeout' => timeout }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Description:**

This PR addresses issue #47 by decomposing the monolithic RubyAsterisk::AMI::Client class. Specific command logic has been extracted into separate modules (Mixins) organized by category to improve maintainability and readability.

**Changes:**

• Created a new directory structure: lib/ruby-asterisk/ami/commands/.
• Extracted methods into the following specialized modules:
  • System (login, logoff, ping, events)
  • Channel (originate, hangup, redirect, status)
  • Queue (queue management)
  • Sip (peer/registry info)
  • Monitor (recording controls)
  • Conference (Confbridge/MeetMe)
  • Extension (state, parked calls)
  • Mailbox (status, count)
• Updated AMI::Client to include these modules, retaining only the core connection and execute logic.

**Impact:**

• Significantly reduced the line count of client.rb (approx. 70% reduction).
• Clearer separation of concerns.
• No changes to the public API (fully backward compatible).
