### PR TITLE
Issue #54 - Implement FastAGI server

### DIFF
--- a/lib/ruby-asterisk.rb
+++ b/lib/ruby-asterisk.rb
@@ -3,3 +3,4 @@
 require 'ruby-asterisk/ami/client'
 require 'ruby-asterisk/ari/client'
 require 'ruby-asterisk/ari/websocket'
+require 'ruby-asterisk/agi/server'

--- a/lib/ruby-asterisk/agi/protocol.rb
+++ b/lib/ruby-asterisk/agi/protocol.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module AGI
+    # Stateless helpers for the FastAGI wire protocol.
+    module Protocol
+      ENV_LINE = /\A(agi_\w+):\s*(.*)/
+      RESPONSE_LINE = /\A(\d{3})\s+(.*)$/
+
+      # Parse a single AGI response line returned by Asterisk.
+      #
+      # Supported formats:
+      #   200 result=<value>
+      #   200 result=<value> endpos=<n>
+      #   200 result=<value> (<extra text>)
+      #   510 Invalid or unknown command
+      #
+      # @param line [String, nil]
+      # @return [Hash] with keys :code (Integer), :result (String|nil), :data (String|nil)
+      def self.parse_response(line)
+        return { code: 0, result: nil, data: 'Connection closed' } if line.nil?
+
+        m = RESPONSE_LINE.match(line.chomp)
+        return { code: 0, result: nil, data: line.chomp } unless m
+
+        code = m[1].to_i
+        rest = m[2]
+
+        result, data = extract_result_and_data(rest)
+        { code: code, result: result, data: data }
+      end
+
+      # @param rest [String] everything after the status code
+      # @return [Array(String|nil, String|nil)]
+      def self.extract_result_and_data(rest)
+        if (rm = rest.match(/\Aresult=(\S*)\s*(.*)?/))
+          result = rm[1].empty? ? nil : rm[1]
+          extra  = rm[2].strip
+          data   = extra.empty? ? nil : extra.delete_prefix('(').delete_suffix(')')
+          [result, data]
+        else
+          [nil, rest.strip.empty? ? nil : rest.strip]
+        end
+      end
+      private_class_method :extract_result_and_data
+    end
+  end
+end

--- a/lib/ruby-asterisk/agi/server.rb
+++ b/lib/ruby-asterisk/agi/server.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'socket'
+require 'logger'
+require_relative 'session'
+require_relative '../../ruby-asterisk/error'
+
+module RubyAsterisk
+  module AGI
+    # FastAGI TCP server.
+    #
+    # Listens on a TCP port and dispatches each incoming Asterisk connection to
+    # a user-supplied handler block running in its own thread.
+    #
+    # Usage:
+    #   server = RubyAsterisk::AGI::Server.new('0.0.0.0', 4573)
+    #   server.handle { |session| session.answer }
+    #   server.run         # blocks until server.stop is called
+    class Server
+      attr_reader :host, :port, :running
+
+      alias running? running
+
+      def initialize(host, port, logger: Logger.new($stdout))
+        @host    = host
+        @port    = port.to_i
+        @logger  = logger
+        @handler = nil
+        @threads = []
+        @running = false
+        @server  = nil
+        @mutex   = Mutex.new
+      end
+
+      # Register the per-connection handler block.
+      #
+      # @yield [RubyAsterisk::AGI::Session]
+      # @return [self]
+      def handle(&block)
+        @handler = block
+        self
+      end
+
+      # Start accepting connections (blocks until {#stop} is called).
+      #
+      # @raise [RubyAsterisk::Error] if no handler has been registered
+      def run
+        raise Error, 'No handler registered' unless @handler
+
+        @server  = TCPServer.new(@host, @port)
+        @port    = @server.addr[1]
+        @running = true
+        @logger.info("AGI server listening on #{@host}:#{@port}")
+        accept_loop
+      ensure
+        @running = false
+        close_server
+      end
+
+      # Stop the server and wait for active connection threads to finish.
+      def stop
+        return unless @running
+
+        @running = false
+        close_server
+        join_threads
+      end
+
+      private
+
+      def accept_loop
+        loop do
+          socket = @server.accept
+          @mutex.synchronize do
+            @threads.delete_if { |t| !t.alive? }
+            @threads << Thread.new(socket) { |s| serve(s) }
+          end
+        end
+      rescue IOError, Errno::EBADF
+        # Server socket closed via stop — normal shutdown
+      end
+
+      def serve(socket)
+        session = Session.new(socket, logger: @logger)
+        session.read_env
+        @handler.call(session)
+      rescue StandardError => e
+        @logger.error("AGI session error: #{e.message}")
+      ensure
+        socket.close rescue nil # rubocop:disable Style/RescueModifier
+      end
+
+      def close_server
+        @server&.close
+        @server = nil
+      rescue StandardError
+        nil
+      end
+
+      def join_threads
+        threads = @mutex.synchronize { @threads.dup }
+        threads.each { |t| t.join(2) || t.kill }
+        @mutex.synchronize { @threads.clear }
+      end
+    end
+  end
+end

--- a/lib/ruby-asterisk/agi/session.rb
+++ b/lib/ruby-asterisk/agi/session.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'logger'
+require_relative 'protocol'
+require_relative '../../ruby-asterisk/error'
+
+module RubyAsterisk
+  module AGI
+    # Wraps a single FastAGI connection.
+    #
+    # Parses the AGI environment block sent by Asterisk at connection start,
+    # then provides command methods that write AGI commands and return parsed
+    # response hashes.
+    class Session
+      attr_reader :env, :socket
+
+      def initialize(socket, logger: Logger.new($stdout))
+        @socket = socket
+        @logger = logger
+        @env    = {}
+      end
+
+      # Read the AGI environment block (agi_key: value lines until blank line).
+      def read_env
+        while (line = @socket.gets)
+          break if line.chomp.empty?
+
+          m = Protocol::ENV_LINE.match(line.chomp)
+          if m
+            @env[m[1]] = m[2].strip
+          else
+            @logger.debug("AGI env: unexpected line: #{line.chomp}")
+          end
+        end
+      end
+
+      # Send a raw AGI command and return the parsed response Hash.
+      #
+      # @param command_string [String]
+      # @return [Hash] { code: Integer, result: String|nil, data: String|nil }
+      # @raise [RubyAsterisk::Error] on EOF or 5xx response
+      def execute(command_string)
+        @socket.write("#{command_string}\n")
+        line = @socket.gets
+        raise Error, 'Connection closed by Asterisk' unless line
+
+        response = Protocol.parse_response(line)
+        raise Error, "AGI error (#{response[:code]}): #{response[:data]}" if response[:code] >= 500
+
+        response
+      end
+
+      def answer
+        execute('ANSWER')
+      end
+
+      def hangup(channel = nil)
+        execute(channel ? "HANGUP #{channel}" : 'HANGUP')
+      end
+
+      def stream_file(filename, escape_digits = '')
+        execute(%(STREAM FILE "#{filename}" "#{escape_digits}"))
+      end
+
+      def say_digits(digits, escape_digits = '')
+        execute(%(SAY DIGITS #{digits} "#{escape_digits}"))
+      end
+
+      def say_number(number, escape_digits = '')
+        execute(%(SAY NUMBER #{number} "#{escape_digits}"))
+      end
+
+      def exec(application, *args)
+        execute(%(EXEC #{application} "#{args.join(',')}"))
+      end
+
+      def set_variable(name, value)
+        execute(%(SET VARIABLE #{name} "#{value}"))
+      end
+
+      def get_variable(name)
+        execute("GET VARIABLE #{name}")
+      end
+
+      def get_data(filename, timeout: 5000, max_digits: 1024)
+        execute(%(GET DATA "#{filename}" #{timeout} #{max_digits}))
+      end
+
+      def verbose(message, level: 1)
+        execute(%(VERBOSE "#{message}" #{level}))
+      end
+    end
+  end
+end

--- a/spec/ruby-asterisk/agi/protocol_spec.rb
+++ b/spec/ruby-asterisk/agi/protocol_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ruby-asterisk/agi/protocol'
+
+RSpec.describe RubyAsterisk::AGI::Protocol do
+  describe '.parse_response' do
+    subject(:parse) { described_class.parse_response(line) }
+
+    context 'with a plain success result' do
+      let(:line) { '200 result=1' }
+
+      it { expect(parse).to eq(code: 200, result: '1', data: nil) }
+    end
+
+    context 'with result=0' do
+      let(:line) { '200 result=0' }
+
+      it { expect(parse).to eq(code: 200, result: '0', data: nil) }
+    end
+
+    context 'with endpos extra data' do
+      let(:line) { '200 result=0 endpos=12345' }
+
+      it { expect(parse).to eq(code: 200, result: '0', data: 'endpos=12345') }
+    end
+
+    context 'with parenthetical extra data' do
+      let(:line) { '200 result=1 (some text)' }
+
+      it { expect(parse).to eq(code: 200, result: '1', data: 'some text') }
+    end
+
+    context 'with trailing newline' do
+      let(:line) { "200 result=1\n" }
+
+      it { expect(parse[:code]).to eq(200) }
+      it { expect(parse[:result]).to eq('1') }
+    end
+
+    context 'with 510 error' do
+      let(:line) { '510 Invalid or unknown command' }
+
+      it { expect(parse).to eq(code: 510, result: nil, data: 'Invalid or unknown command') }
+    end
+
+    context 'with 511 error' do
+      let(:line) { '511 Command Not Permitted on a dead channel' }
+
+      it { expect(parse).to eq(code: 511, result: nil, data: 'Command Not Permitted on a dead channel') }
+    end
+
+    context 'with nil (socket EOF)' do
+      let(:line) { nil }
+
+      it { expect(parse).to eq(code: 0, result: nil, data: 'Connection closed') }
+    end
+
+    context 'with an unrecognised line' do
+      let(:line) { 'INVALID' }
+
+      it { expect(parse[:code]).to eq(0) }
+    end
+  end
+end

--- a/spec/ruby-asterisk/agi/server_spec.rb
+++ b/spec/ruby-asterisk/agi/server_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ruby-asterisk/agi/server'
+require 'socket'
+require 'timeout'
+
+# Starts an AGI server on an ephemeral port and returns [server, server_thread, port].
+# Automatically registers an after hook that calls stop and joins the thread.
+def start_test_server(server, &)
+  server.handle(&)
+  thread = Thread.new { server.run }
+  Timeout.timeout(2) { sleep 0.01 until server.running? || !thread.alive? }
+  raise 'Server did not start' unless server.running?
+
+  [thread, server.port]
+end
+
+# Connect as a fake Asterisk client, send env + responses, collect written commands.
+def fake_asterisk_session(port, env_lines: [], responses: [])
+  socket = TCPSocket.new('127.0.0.1', port)
+  # Send env block
+  env_lines.each { |l| socket.puts(l) }
+  socket.puts('') # blank line terminates env
+
+  received_commands = []
+  responses.each do |resp|
+    cmd = socket.gets
+    received_commands << cmd.chomp if cmd
+    socket.puts(resp)
+  end
+
+  socket.close
+  received_commands
+rescue StandardError => e
+  socket&.close
+  raise e
+end
+
+RSpec.describe RubyAsterisk::AGI::Server do
+  let(:logger) { instance_double(Logger, info: nil, warn: nil, error: nil, debug: nil) }
+  subject(:server) { described_class.new('127.0.0.1', 0, logger: logger) }
+
+  after do
+    server.stop if server.running?
+  end
+
+  describe '#initialize' do
+    it 'stores the host' do
+      expect(server.host).to eq('127.0.0.1')
+    end
+
+    it 'starts with running? false' do
+      expect(server.running?).to be(false)
+    end
+  end
+
+  describe '#handle' do
+    it 'stores the handler and returns self' do
+      result = server.handle { |s| s }
+      expect(result).to be(server)
+    end
+  end
+
+  describe '#run' do
+    it 'raises RubyAsterisk::Error when no handler is registered' do
+      expect { server.run }.to raise_error(RubyAsterisk::Error, /No handler registered/)
+    end
+
+    it 'blocks and sets running? to true while accepting' do
+      _thread, _port = start_test_server(server) { |_s| nil }
+      expect(server.running?).to be(true)
+    end
+
+    it 'sets running? back to false after stop' do
+      thread, = start_test_server(server) { |_s| nil }
+      server.stop
+      thread.join(2)
+      expect(server.running?).to be(false)
+    end
+
+    it 'updates port to the actual bound port when given 0' do
+      start_test_server(server) { |_s| nil }
+      expect(server.port).to be > 0
+    end
+  end
+
+  describe 'connection handling' do
+    it 'invokes the handler with a Session for each connection' do
+      sessions_seen = []
+      _thread, port = start_test_server(server) do |session|
+        sessions_seen << session
+      end
+
+      fake_asterisk_session(port, env_lines: ['agi_channel: SIP/test'])
+      sleep 0.1
+      server.stop
+
+      expect(sessions_seen.length).to eq(1)
+      expect(sessions_seen.first).to be_a(RubyAsterisk::AGI::Session)
+    end
+
+    it 'populates session.env from the AGI environment block' do
+      captured_env = nil
+      _thread, port = start_test_server(server) do |session|
+        captured_env = session.env.dup
+      end
+
+      fake_asterisk_session(port, env_lines: ['agi_channel: SIP/alice', 'agi_callerid: 5551234'])
+      sleep 0.1
+      server.stop
+
+      expect(captured_env['agi_channel']).to eq('SIP/alice')
+      expect(captured_env['agi_callerid']).to eq('5551234')
+    end
+
+    it 'exchanges AGI commands and responses correctly' do
+      _thread, port = start_test_server(server) do |session|
+        session.answer
+        session.hangup
+      end
+
+      cmds = fake_asterisk_session(port,
+                                   env_lines: ['agi_channel: SIP/test'],
+                                   responses: ['200 result=1', '200 result=1'])
+      server.stop
+
+      expect(cmds).to eq(%w[ANSWER HANGUP])
+    end
+
+    it 'does not crash the accept loop when a handler raises' do
+      call_count = 0
+      _thread, port = start_test_server(server) do |_session|
+        call_count += 1
+        raise 'deliberate error' if call_count == 1
+      end
+
+      fake_asterisk_session(port, env_lines: [])
+      sleep 0.05
+      fake_asterisk_session(port, env_lines: [])
+      sleep 0.05
+      server.stop
+
+      expect(call_count).to eq(2)
+      expect(logger).to have_received(:error).at_least(:once)
+    end
+  end
+
+  describe 'concurrency' do
+    it 'handles multiple simultaneous connections in parallel' do
+      guard   = Mutex.new
+      started = 0
+      finished = 0
+
+      _thread, port = start_test_server(server) do |_session|
+        guard.synchronize { started += 1 }
+        sleep 0.2
+        guard.synchronize { finished += 1 }
+      end
+
+      start = Time.now
+
+      Array.new(5) do
+        Thread.new do
+          fake_asterisk_session(port, env_lines: [])
+        rescue StandardError
+          nil
+        end
+      end.each(&:join)
+
+      # Wait until all 5 handlers have started before timing the parallel phase.
+      Timeout.timeout(2) { sleep 0.01 until started == 5 }
+
+      # Joining server threads proves they all ran concurrently.
+      server.stop
+      elapsed = Time.now - start
+
+      expect(finished).to eq(5)
+      expect(elapsed).to be < 0.8
+    end
+  end
+
+  describe '#stop' do
+    it 'is idempotent — calling twice does not raise' do
+      start_test_server(server) { |_s| nil }
+      server.stop
+      expect { server.stop }.not_to raise_error
+    end
+  end
+end

--- a/spec/ruby-asterisk/agi/session_spec.rb
+++ b/spec/ruby-asterisk/agi/session_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ruby-asterisk/agi/session'
+require 'stringio'
+
+RSpec.describe RubyAsterisk::AGI::Session do
+  # A fake socket backed by StringIO for reads and a StringIO capture for writes.
+  def fake_socket(input_string, responses: [])
+    reader = StringIO.new(input_string)
+    writer = StringIO.new
+    socket = double('socket')
+
+    allow(socket).to receive(:gets) do
+      line = reader.gets
+      line || responses.shift
+    end
+    allow(socket).to receive(:write) { |data| writer.write(data) }
+
+    [socket, writer]
+  end
+
+  # Builds a socket whose reads cycle through env_block then response_lines
+  def session_socket(env_block, response_lines)
+    all_input = env_block + response_lines.map { |l| "#{l}\n" }.join
+    socket, writer = fake_socket(all_input)
+    [socket, writer]
+  end
+
+  let(:logger) { instance_double(Logger, debug: nil, info: nil, warn: nil, error: nil) }
+
+  describe '#read_env' do
+    it 'parses agi_* key/value pairs from the env block' do
+      env_block = "agi_channel: SIP/test-1\nagi_callerid: 1000\n\n"
+      socket, = fake_socket(env_block)
+      session = described_class.new(socket, logger: logger)
+      session.read_env
+
+      expect(session.env['agi_channel']).to eq('SIP/test-1')
+      expect(session.env['agi_callerid']).to eq('1000')
+    end
+
+    it 'stops at the blank line' do
+      env_block = "agi_channel: SIP/test-1\n\nagi_after_blank: ignored\n"
+      socket, = fake_socket(env_block)
+      session = described_class.new(socket, logger: logger)
+      session.read_env
+
+      expect(session.env).not_to have_key('agi_after_blank')
+    end
+
+    it 'ignores non-agi lines with a debug log' do
+      env_block = "agi_channel: SIP/x\nunknown line\n\n"
+      socket, = fake_socket(env_block)
+      session = described_class.new(socket, logger: logger)
+      session.read_env
+
+      expect(logger).to have_received(:debug).with(/unexpected line/)
+      expect(session.env.keys).to eq(['agi_channel'])
+    end
+  end
+
+  describe '#execute' do
+    subject(:session) { described_class.new(socket, logger: logger) }
+
+    let(:socket) do
+      s, = session_socket('', ['200 result=1'])
+      s
+    end
+
+    it 'returns a parsed response hash' do
+      result = session.execute('ANSWER')
+      expect(result).to eq(code: 200, result: '1', data: nil)
+    end
+
+    it 'raises RubyAsterisk::Error on 5xx response' do
+      s = double('socket')
+      allow(s).to receive(:write)
+      allow(s).to receive(:gets).and_return("510 Invalid or unknown command\n")
+      session = described_class.new(s, logger: logger)
+
+      expect { session.execute('BADCMD') }.to raise_error(RubyAsterisk::Error, /510/)
+    end
+
+    it 'raises RubyAsterisk::Error on EOF (nil)' do
+      s = double('socket')
+      allow(s).to receive(:write)
+      allow(s).to receive(:gets).and_return(nil)
+      session = described_class.new(s, logger: logger)
+
+      expect { session.execute('ANSWER') }.to raise_error(RubyAsterisk::Error)
+    end
+  end
+
+  describe 'command wrappers' do
+    let(:written) { StringIO.new }
+    let(:socket) do
+      s = double('socket')
+      allow(s).to receive(:write) { |data| written.write(data) }
+      allow(s).to receive(:gets).and_return("200 result=1\n")
+      s
+    end
+    subject(:session) { described_class.new(socket, logger: logger) }
+
+    it '#answer writes ANSWER command' do
+      session.answer
+      expect(written.string).to eq("ANSWER\n")
+    end
+
+    it '#hangup writes HANGUP without channel' do
+      session.hangup
+      expect(written.string).to eq("HANGUP\n")
+    end
+
+    it '#hangup writes HANGUP with channel' do
+      session.hangup('SIP/1001')
+      expect(written.string).to eq("HANGUP SIP/1001\n")
+    end
+
+    it '#stream_file quotes filename and escape_digits' do
+      session.stream_file('hello-world', '#*')
+      expect(written.string).to eq(%(STREAM FILE "hello-world" "#*"\n))
+    end
+
+    it '#stream_file uses empty escape_digits by default' do
+      session.stream_file('hello-world')
+      expect(written.string).to eq(%(STREAM FILE "hello-world" ""\n))
+    end
+
+    it '#say_digits writes SAY DIGITS command' do
+      session.say_digits('1234')
+      expect(written.string).to eq(%(SAY DIGITS 1234 ""\n))
+    end
+
+    it '#say_number writes SAY NUMBER command' do
+      session.say_number(42)
+      expect(written.string).to eq(%(SAY NUMBER 42 ""\n))
+    end
+
+    it '#exec writes EXEC command with joined args' do
+      session.exec('AGICommand', 'arg1', 'arg2')
+      expect(written.string).to eq(%(EXEC AGICommand "arg1,arg2"\n))
+    end
+
+    it '#set_variable writes SET VARIABLE command' do
+      session.set_variable('MYVAR', 'hello')
+      expect(written.string).to eq(%(SET VARIABLE MYVAR "hello"\n))
+    end
+
+    it '#get_variable writes GET VARIABLE command' do
+      session.get_variable('MYVAR')
+      expect(written.string).to eq("GET VARIABLE MYVAR\n")
+    end
+
+    it '#get_data writes GET DATA command with defaults' do
+      session.get_data('silence')
+      expect(written.string).to eq(%(GET DATA "silence" 5000 1024\n))
+    end
+
+    it '#get_data accepts timeout and max_digits overrides' do
+      session.get_data('beep', timeout: 3000, max_digits: 4)
+      expect(written.string).to eq(%(GET DATA "beep" 3000 4\n))
+    end
+
+    it '#verbose writes VERBOSE command' do
+      session.verbose('test message', level: 2)
+      expect(written.string).to eq(%(VERBOSE "test message" 2\n))
+    end
+  end
+end


### PR DESCRIPTION
**Componenti aggiunti:**

- `RubyAsterisk::AGI::Protocol` — parsing delle response line AGI (`200 result=1`, `510 …`, EOF)
- `RubyAsterisk::AGI::Session` — legge l'env block AGI e wrappa 10 comandi: `answer`, `hangup`, `stream_file`, `say_digits`, `say_number`, `exec`, `set_variable`, `get_variable`, `get_data`, `verbose`
- `RubyAsterisk::AGI::Server` — accetta connessioni TCP, un Thread per connessione, `handle`/`run`/`stop`

**API:**

\`\`\`ruby
server = RubyAsterisk::AGI::Server.new('0.0.0.0', 4573)
server.handle do |session|
  session.answer
  session.stream_file('hello-world')
end
server.run
\`\`\`
