### PR TITLE
Issue #70 - Update README, add CHANGELOG and LLM skill files; bump to 1.0.0

### DIFF
--- a/.claude/skills/ruby-asterisk-agi/SKILL.md
+++ b/.claude/skills/ruby-asterisk-agi/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: ruby-asterisk-agi
+description: Build AGI/FastAGI dialplan logic in Ruby with ruby-asterisk: Server (Async+Fiber), Session command verbs, Protocol parsing, IVR patterns, 520 multi-line error handling.
+---
+
+# ruby-asterisk AGI / FastAGI
+
+## When to use this skill
+
+Use this skill when writing Ruby code that Asterisk calls via `AGI(agi://host:port)`. ruby-asterisk provides a FastAGI TCP server (`AGI::Server`) backed by the `async` gem's Fiber scheduler, plus a `Session` class with the full set of AGI command verbs.
+
+## Core concepts
+
+### Architecture
+
+```
+Asterisk          ruby-asterisk FastAGI server
+   |                      |
+   |--- TCP connect -----> AGI::Server (TCPServer + Async Sync)
+   |                             |
+   |                     spawns Fiber per connection
+   |                             |
+   |--- ENV block -------> Session#read_env  (parse agi_* vars)
+   |--- CMD response <---- Session#<verb>    (write command, read result)
+   |--- CMD response <---- ...
+   |--- EOF / hangup ----> Fiber exits, socket closed
+```
+
+Each connection runs in its own **Fiber** sharing one OS thread. Socket reads/writes yield the Fiber rather than blocking, so thousands of simultaneous calls can be handled efficiently.
+
+### Session execute model
+
+Every command method writes a line to the socket and reads back a response:
+
+```ruby
+# Low-level (rarely called directly):
+response = session.execute('ANSWER')
+# => { code: 200, result: "0", data: nil }
+
+# High-level convenience methods:
+session.answer     # => { code: 200, result: "0", data: nil }
+```
+
+`execute` raises `RubyAsterisk::Error` on:
+- EOF from Asterisk (`"Connection closed by Asterisk"`)
+- Any 5xx response, after collecting the full `520-…/520 End of proper usage.` multi-line error body
+
+### Protocol module
+
+`RubyAsterisk::AGI::Protocol` is a stateless utility module (all class methods):
+
+| Method | Purpose |
+|---|---|
+| `format_command(cmd, *args)` | Build a `"CMD arg1 arg2\n"` string with argument escaping |
+| `escape_argument(arg)` | Pass through bare words; double-quote strings with spaces/special chars |
+| `quote(arg)` | **Always** double-quote (use for filenames, variable values, messages) |
+| `parse_response(line)` | Parse `"200 result=0 (data)"` → `{code:, result:, data:}` frozen Hash |
+| `parse_env_line(line)` | Parse one `"agi_key: value"` line → `[key, value]` or `nil` |
+| `parse_env_block(io, &block)` | Read env lines until blank, return `Hash{String=>String}` |
+| `collect_multiline_error(first_line, first_resp, io)` | Drain 520 continuation lines |
+| `error?(response)` | `response[:code] >= 500` |
+
+**`quote` vs `escape_argument`**: use `quote` for filenames, variable values, and text that Asterisk requires always quoted; use `escape_argument` for digit-escape lists and simple identifiers that only need quoting when they contain spaces or special characters.
+
+## FastAGI server
+
+### Minimal setup
+
+```ruby
+require 'ruby-asterisk'
+
+server = RubyAsterisk::AGI::Server.new('0.0.0.0', 4573)
+server.handle do |session|
+  session.answer
+  session.stream_file('hello-world')
+  session.hangup
+end
+server.run   # blocks until server.stop is called
+```
+
+In Asterisk `extensions.conf`:
+
+```
+exten => 100,1,AGI(agi://192.168.1.100:4573)
+```
+
+### Server API
+
+| Method | Signature | Notes |
+|---|---|---|
+| `new` | `(host, port, logger: Logger.new($stdout))` | `port: 0` → ephemeral |
+| `handle` | `(&block)` | Must be called before `run`; returns `self` |
+| `run` | — | Blocks; raises `Error` if no handler |
+| `stop` | — | Closes listener; active sessions finish naturally |
+| `running?` | — | Boolean |
+| `port` | — | Actual bound port (useful when `port: 0`) |
+
+## Session command verbs
+
+All methods return `{ code: Integer, result: String|nil, data: String|nil }`.
+
+### Lifecycle and environment
+
+```ruby
+session.read_env     # parse initial agi_* block; fills session.env
+session.env          # => { "agi_channel" => "SIP/alice-001", "agi_callerid" => "...", ... }
+session.execute(cmd) # low-level: write cmd, read one response line
+```
+
+### Call control
+
+```ruby
+session.answer
+session.hangup
+session.hangup('SIP/alice-001')   # explicit channel
+session.channel_status            # status of current channel (returns numeric code in result)
+session.channel_status('SIP/b')   # explicit channel
+```
+
+### Audio playback
+
+```ruby
+session.stream_file('hello-world')           # play sound; no interrupt
+session.stream_file('hello-world', '1234')   # play; stop on digit 1/2/3/4
+session.stream_file('hello-world', '#*')     # stop on # or *
+
+session.say_digits('12345')
+session.say_digits('12345', '#')             # stop on #
+
+session.say_number(42)
+session.say_number(42, '#')
+```
+
+### DTMF / input collection
+
+```ruby
+result = session.get_data('enter-pin', timeout: 5000, max_digits: 4)
+puts result[:data]   # => "1234" (digits entered) or "" on timeout
+
+digit_ascii = session.wait_for_digit(5000)  # returns ASCII int, -1 on timeout
+char = digit_ascii.chr if digit_ascii > 0
+```
+
+### Variables
+
+```ruby
+session.set_variable('MY_VAR', 'hello world')
+response = session.get_variable('MY_VAR')
+puts response[:data]   # => "hello world"
+```
+
+### Recording
+
+```ruby
+session.record_file(
+  '/tmp/voicemail',      # filename (no extension)
+  format: 'wav',         # default: 'wav'
+  escape_digits: '#',    # stop on # (default)
+  timeout_ms: 30_000,    # -1 = no timeout (default)
+  offset: 0,
+  beep: true,            # play beep before recording (default)
+  silence: 3             # stop after 3 s of silence (optional)
+)
+```
+
+### Dialplan application execution
+
+```ruby
+session.exec('Playback', 'hello-world')
+session.exec('AGI', 'script.agi')
+session.dial('PJSIP/bob', timeout: 30, options: 'r')   # wraps Exec Dial
+```
+
+### AstDB operations
+
+```ruby
+session.database_put('myapp', 'last_caller', '0391234567')
+response = session.database_get('myapp', 'last_caller')
+puts response[:data]                              # => "0391234567"
+session.database_del('myapp', 'last_caller')
+session.database_deltree('myapp')                 # delete whole family
+session.database_deltree('myapp', 'sub/tree')     # delete sub-tree
+```
+
+### Utilities
+
+```ruby
+session.verbose('Starting IVR', level: 2)         # log to Asterisk CLI
+session.send_text('Hello from FastAGI')
+session.send_image('logo.png')
+```
+
+## Patterns
+
+### Pattern 1: Minimal FastAGI (answer → play → hangup)
+
+```ruby
+server = RubyAsterisk::AGI::Server.new('0.0.0.0', 4573)
+server.handle { |s| s.answer; s.stream_file('hello-world'); s.hangup }
+server.run
+```
+
+### Pattern 2: IVR with DTMF branching
+
+```ruby
+server = RubyAsterisk::AGI::Server.new('0.0.0.0', 4573)
+server.handle do |session|
+  session.answer
+
+  result = session.get_data('ivr-welcome', timeout: 5000, max_digits: 1)
+  choice = result[:data].to_s.strip
+
+  case choice
+  when '1'
+    session.dial('PJSIP/sales', timeout: 30)
+  when '2'
+    session.dial('PJSIP/support', timeout: 30)
+  when '0'
+    session.exec('VoiceMail', '1000@default')
+  else
+    session.stream_file('invalid-option')
+    session.hangup
+  end
+end
+server.run
+```
+
+### Pattern 3: Recording with error handling
+
+```ruby
+server = RubyAsterisk::AGI::Server.new('0.0.0.0', 4573)
+server.handle do |session|
+  session.answer
+  session.stream_file('record-after-beep')
+
+  begin
+    session.record_file('/tmp/greeting',
+                        format: 'wav',
+                        escape_digits: '#',
+                        timeout_ms: 30_000,
+                        beep: true,
+                        silence: 3)
+
+    session.database_put('greetings', 'latest', '/tmp/greeting.wav')
+    session.stream_file('your-recording-has-been-saved')
+  rescue RubyAsterisk::Error => e
+    # e.message contains the full 520 multi-line error body if applicable
+    session.verbose("Recording failed: #{e.message}", level: 1)
+    session.stream_file('an-error-occurred')
+  ensure
+    session.hangup
+  end
+end
+server.run
+```
+
+### Pattern 4: All verbs — quick reference snippets
+
+```ruby
+# ---- Call control ----
+session.answer                                    # ANSWER
+session.hangup                                    # HANGUP
+session.hangup('SIP/channel-001')                 # HANGUP <channel>
+session.channel_status                            # CHANNEL STATUS
+session.channel_status('SIP/channel-001')         # CHANNEL STATUS <channel>
+
+# ---- Playback ----
+session.stream_file('hello-world', '')            # STREAM FILE "hello-world" ""
+session.say_digits('123', '#')                    # SAY DIGITS 123 "#"
+session.say_number(42, '')                        # SAY NUMBER 42 ""
+
+# ---- Input ----
+session.get_data('enter-pin', timeout: 5000, max_digits: 4)  # GET DATA "enter-pin" 5000 4
+session.wait_for_digit(5000)                      # WAIT FOR DIGIT 5000
+
+# ---- Variables ----
+session.set_variable('FOO', 'bar baz')            # SET VARIABLE FOO "bar baz"
+session.get_variable('FOO')                       # GET VARIABLE FOO
+
+# ---- Recording ----
+session.record_file('/tmp/rec', format: 'wav', beep: true, silence: 3)
+
+# ---- Execution ----
+session.exec('Playback', 'hello-world')           # EXEC Playback "hello-world"
+session.dial('PJSIP/alice', timeout: 30)          # EXEC Dial "PJSIP/alice,30"
+session.verbose('log me', level: 1)               # VERBOSE "log me" 1
+
+# ---- Text / image ----
+session.send_text('Hello')                        # SEND TEXT "Hello"
+session.send_image('logo.png')                    # SEND IMAGE logo.png
+
+# ---- AstDB ----
+session.database_put('family', 'key', 'value')    # DATABASE PUT family key "value"
+session.database_get('family', 'key')             # DATABASE GET family key
+session.database_del('family', 'key')             # DATABASE DEL family key
+session.database_deltree('family')                # DATABASE DELTREE family
+session.database_deltree('family', 'sub')         # DATABASE DELTREE family sub
+```
+
+## Gotchas
+
+- **`handle` is mandatory** before `run`; calling `run` without it raises `RubyAsterisk::Error`.
+- **`execute` raises on EOF** (`"Connection closed by Asterisk"`) and on any 5xx, including `520-…` multi-line errors. All command methods propagate this.
+- **`Protocol.quote` vs `escape_argument`**: always use `quote` for filenames, variable values, and text content. Use `escape_argument` for digit-escape strings or other tokens that only need quoting conditionally.
+- **Ruby 3.1**: an `IO#timeout` / `IO#timeout=` shim is applied at load time in `agi/server.rb`. Required because the `async` gem calls `io.timeout` inside its scheduler on Ruby 3.2+ — the shim returns `nil` on 3.1 to disable that path. Never remove it while Ruby 3.1 is in the support matrix.
+- **CPU-bound work in handlers** will block the shared Fiber scheduler. Offload to a Thread or separate process if you need heavy computation per call.
+- **`session.env` is populated by `read_env`** which is called automatically by `Server#serve`. In tests, call `session.read_env` manually after writing the env block to the socket.
+- The `logger` on `Server` is passed down to each `Session`; unknown AGI env lines (not matching `agi_*:`) are logged at `debug` level.
+
+## Source files
+
+- `lib/ruby-asterisk/agi/server.rb` — `Server` class + `IO#timeout` shim
+- `lib/ruby-asterisk/agi/session.rb` — `Session` class
+- `lib/ruby-asterisk/agi/protocol.rb` — `Protocol` module
+- `spec/ruby-asterisk/agi/server_spec.rb` — server lifecycle + Fiber concurrency proof
+- `spec/ruby-asterisk/agi/session_spec.rb` — all command verbs, error handling
+- `spec/ruby-asterisk/agi/protocol_spec.rb` — parsing and formatting helpers

--- a/.claude/skills/ruby-asterisk-ami/SKILL.md
+++ b/.claude/skills/ruby-asterisk-ami/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: ruby-asterisk-ami
+description: Build an async Asterisk AMI client with ruby-asterisk: connect, login, Promise-based commands (channel, queue, conference, SIP, mailbox, monitor, extension state).
+---
+
+# ruby-asterisk AMI Client
+
+## When to use this skill
+
+Use this skill when writing code that connects to the Asterisk Manager Interface via TCP — for example: originating calls, checking extension state, managing queues, monitoring channels, or handling SIP peers.
+
+## Core concepts
+
+### Every command returns a Promise
+
+```ruby
+promise  = ami.ping          # returns RubyAsterisk::AMI::Promise immediately
+response = promise.value     # blocks up to 5 s (default timeout)
+response = promise.value(10) # custom timeout in seconds
+```
+
+`#value` raises `Timeout::Error` if no response arrives within the timeout.
+`disconnect` rejects all pending promises with `RuntimeError`.
+
+### The Response object
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `success` | Boolean | `true` when raw contains `Response: Success` |
+| `action_id` | String | echoed ActionID |
+| `message` | String | `Message:` field |
+| `data` | Hash / Array | structured, present when action is in `PARSE_DATA` |
+| `raw_response` | String/Array | unprocessed AMI text |
+| `type` | String | AMI action name |
+
+### Connection lifecycle
+
+```ruby
+ami = RubyAsterisk::AMI::Client.new(host: '192.168.1.1', port: 5038)
+ami.connect                                        # starts Ractors + event loop
+ami.login(username: 'admin', secret: 'secret').value
+# ... use commands ...
+ami.logoff.value
+ami.disconnect                                     # stops Ractors, rejects pending promises
+```
+
+`login` auto-calls `connect` if not already connected.
+
+## API reference
+
+### System
+
+| Method | AMI Action | Notes |
+|---|---|---|
+| `ping` | `Ping` | Returns `Pong` response |
+| `command(cmd)` | `Command` | CLI passthrough, e.g. `'core show channels'` |
+| `wait_event(timeout: -1)` | `WaitEvent` | -1 = wait forever; bumps `@timeout` |
+| `event_mask(mask = 'off')` | `Events` | `'on'` / `'off'` / `'system,call'` |
+| `parked_calls` | `ParkedCalls` | |
+| `device_state_list` | `DeviceStateList` | |
+| `skinny_devices` | `SKINNYdevices` | |
+| `skinny_lines` | `SKINNYlines` | |
+
+### Channel
+
+| Method | Signature | AMI Action |
+|---|---|---|
+| `core_show_channels` | — | `CoreShowChannels` |
+| `status` | `(channel: nil, action_id: nil)` | `Status` |
+| `originate` | `(channel, context, callee, priority, variable: nil, caller_id: nil, timeout: 30_000, async: nil)` | `Originate` |
+| `originate_app` | `(channel:, application:, data:, async:)` | `Originate` (Application/Data form) |
+| `redirect` | `(channel, context, callee, priority, variable: nil, caller_id: nil, timeout: 30_000)` | `Redirect` |
+| `hangup` | `(channel)` | `Hangup` |
+| `atxfer` | `(channel:, exten:, context:, priority: '1')` | `Atxfer` |
+
+### Queue
+
+| Method | Signature |
+|---|---|
+| `queues` | — |
+| `queue_status` | — |
+| `queue_summary` | `(queue)` |
+| `queue_add` | `(queue, interface, penalty: 2, paused: false, member_name: '')` |
+| `queue_remove` | `(queue:, interface:)` |
+| `queue_pause` | `(interface:, paused:, queue:, reason: 'none')` |
+
+### Conference
+
+| Method | Signature |
+|---|---|
+| `meet_me_list` | — |
+| `confbridges` | — |
+| `confbridge` | `(conference)` |
+| `confbridge_mute` | `(conference:, channel:)` |
+| `confbridge_unmute` | `(conference:, channel:)` |
+| `confbridge_kick` | `(conference:, channel:)` |
+
+### Mailbox
+
+| Method | Signature |
+|---|---|
+| `mailbox_status` | `(mailbox:, context: 'default')` |
+| `mailbox_count` | `(mailbox:, context: 'default')` |
+
+### SIP
+
+| Method | Signature |
+|---|---|
+| `sip_peers` | — |
+| `sip_show_peer` | `(peer)` |
+| `sip_show_registry` | — |
+
+### Extension
+
+| Method | Signature | Notes |
+|---|---|---|
+| `extension_state` | `(exten:, context:, action_id: nil)` | `data[:hints]` decorated with `DescriptiveStatus` |
+
+### Monitor
+
+| Method | Signature |
+|---|---|
+| `monitor` | `(channel, mix: false, file: nil, format: 'wav')` |
+| `stop_monitor` | `(channel)` |
+| `pause_monitor` | `(channel)` |
+| `unpause_monitor` | `(channel)` |
+| `change_monitor` | `(channel:, file:)` |
+
+## Usage patterns
+
+### Minimal connect + command
+
+```ruby
+ami = RubyAsterisk::AMI::Client.new(host: '127.0.0.1', port: 5038)
+ami.login(username: 'admin', secret: 'secret').value
+response = ami.ping.value
+puts response.success   # => true
+ami.disconnect
+```
+
+### Originate and wait for result
+
+```ruby
+promise  = ami.originate('PJSIP/alice', 'outbound', '0391234567', '1', async: true)
+response = promise.value(30)
+puts response.success
+```
+
+### Poll queue status
+
+```ruby
+loop do
+  members = ami.queue_status.value.data
+  members&.each { |m| puts m.inspect }
+  sleep 5
+end
+```
+
+### Handle Timeout::Error
+
+```ruby
+begin
+  response = ami.originate('SIP/slow', 'default', '100', '1').value(2)
+rescue Timeout::Error
+  puts 'AMI did not respond in time'
+end
+```
+
+## Gotchas
+
+- **ActionID is auto-generated** (nanosecond timestamp in base36) — never pass a duplicate ActionID.
+- **Call `event_mask('on')`** on the connection if you need Asterisk to push async events (e.g. `StasisStart`). Off by default.
+- **`wait_event` bumps `@timeout`** on the client instance — be aware if you share the client across threads.
+- **`disconnect` rejects all pending promises** — check for `RuntimeError` if you disconnect mid-flight.
+- **`PARSE_DATA`** (`lib/ruby-asterisk/parsing_constants.rb`) controls which responses get structured `data`; unlisted actions return the raw string.
+- The version constant is now `RubyAsterisk::VERSION` (was `Rami::VERSION` before 1.0.0).
+
+## Source files
+
+- `lib/ruby-asterisk/ami/client.rb` — `Client` class
+- `lib/ruby-asterisk/ami/promise.rb` — `Promise` class
+- `lib/ruby-asterisk/ami/commands/*.rb` — command modules
+- `lib/ruby-asterisk/response.rb` — `Response` class
+- `lib/ruby-asterisk/parsing_constants.rb` — `PARSE_DATA`, `DESCRIPTIVE_STATUS`
+- `spec/ruby-asterisk/ami/async_client_spec.rb` — integration tests

--- a/.claude/skills/ruby-asterisk-ari-websocket/SKILL.md
+++ b/.claude/skills/ruby-asterisk-ari-websocket/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: ruby-asterisk-ari-websocket
+description: Receive real-time ARI events from Asterisk via WebSocket with ruby-asterisk: StasisStart, ChannelStateChange, auto-reconnect, ping keep-alive, per-event callbacks.
+---
+
+# ruby-asterisk ARI WebSocket Client
+
+## When to use this skill
+
+Use this skill when you need to react to Asterisk events in real time — for example: starting call handling logic when a Stasis call arrives (`StasisStart`), updating a dashboard on channel state changes, or forwarding events to another system.
+
+## Core concepts
+
+- The WebSocket client runs an **EventMachine reactor in a background thread**. `connect` returns immediately; event processing happens in that thread.
+- Register handlers with `on(event_type, &block)` before or after connecting — handlers are stored and called whenever a matching event arrives.
+- **Multiple handlers** for the same event type are supported; all are called in registration order.
+- Auto-reconnect is enabled by default. When the connection drops, the client waits `reconnect_delay` seconds and reconnects. Set `auto_reconnect: false` to disable.
+- A ping is sent every `ping_interval` seconds to keep the connection alive.
+
+## Initialize
+
+```ruby
+require 'ruby-asterisk'
+
+ws = RubyAsterisk::ARI::WebSocket.new(
+  'http://192.168.1.1:8088',    # ARI base URL
+  'my_api_key',                 # API key (HTTP Basic auth username)
+  'my_stasis_app',              # Stasis application name
+  auto_reconnect:  true,        # default: true
+  reconnect_delay: 5,           # seconds between reconnect attempts; default: 5
+  ping_interval:   30,          # keep-alive ping interval in seconds; default: 30
+  logger:          Logger.new($stdout)
+)
+```
+
+## API reference
+
+| Method | Signature | Notes |
+|---|---|---|
+| `on` | `(event_type, &block)` | Register a callback; `event_type` is a String or Symbol |
+| `connect` | `(&block)` | Start the connection; optional block called on connect |
+| `connected?` | — | `true` if socket is open and in OPEN state |
+| `send_message?` | `(message)` | Send Hash (auto-JSON) or String; returns `false` if not connected |
+| `disconnect` | — | Close the socket and disable auto-reconnect |
+
+Constants (readable as class constants):
+
+| Constant | Default |
+|---|---|
+| `PING_INTERVAL` | 30 s |
+| `RECONNECT_DELAY` | 5 s |
+| `MAX_RECONNECT_ATTEMPTS` | `nil` (infinite) |
+
+## Common ARI event types
+
+| Event type | When fired |
+|---|---|
+| `StasisStart` | A channel enters your Stasis application |
+| `StasisEnd` | A channel leaves your Stasis application |
+| `ChannelStateChange` | Channel state changes (ringing, up, etc.) |
+| `ChannelDtmfReceived` | DTMF digit received on a channel |
+| `ChannelHangupRequest` | Hangup requested on a channel |
+| `BridgeCreated` / `BridgeDestroyed` | Bridge lifecycle |
+| `ChannelEnteredBridge` / `ChannelLeftBridge` | Channel bridge membership |
+| `PlaybackStarted` / `PlaybackFinished` | Media playback lifecycle |
+
+Event payloads are plain Ruby Hashes (parsed from JSON). The outer `type` key matches the event type string.
+
+## Usage patterns
+
+### React to incoming Stasis calls
+
+```ruby
+ws.on('StasisStart') do |event|
+  channel_id = event['channel']['id']
+  caller_id  = event.dig('channel', 'caller', 'number')
+  puts "Incoming call from #{caller_id} on #{channel_id}"
+
+  # Use ARI HTTP client to control the channel
+  http = RubyAsterisk::ARI::Client.new('http://192.168.1.1:8088', 'key', 'my_stasis_app')
+  http.channels.get(channel_id).answer
+end
+
+ws.connect
+sleep   # keep main thread alive
+```
+
+### Handle disconnect and cleanup
+
+```ruby
+ws.on('StasisEnd') do |event|
+  puts "Call ended: #{event['channel']['id']}"
+end
+
+ws.connect do
+  puts "Connected to ARI WebSocket"
+end
+
+# Graceful shutdown
+at_exit { ws.disconnect }
+```
+
+### Conditional forwarding
+
+```ruby
+ws.on('ChannelStateChange') do |event|
+  next unless event.dig('channel', 'state') == 'Up'
+
+  channel_id = event['channel']['id']
+  puts "Channel #{channel_id} is now answered"
+end
+```
+
+### Combine with ARI HTTP client
+
+```ruby
+http = RubyAsterisk::ARI::Client.new('http://192.168.1.1:8088', 'key', 'app')
+
+ws = RubyAsterisk::ARI::WebSocket.new('http://192.168.1.1:8088', 'key', 'app')
+ws.on('StasisStart') do |event|
+  channel = http.channels.get(event['channel']['id'])
+  channel.answer
+  channel.play('sound:hello-world')
+end
+
+ws.connect
+sleep
+```
+
+## Gotchas
+
+- **`connect` is non-blocking** — it starts a background EventMachine thread and returns `self`. The main thread must stay alive (e.g. `sleep`) for the event loop to run.
+- **Callbacks execute in the EventMachine thread** — avoid long-running or blocking operations in callbacks; offload to a separate thread if needed.
+- **`send_message?` returns `false`** when not connected — always check the return value if delivery matters.
+- **Auto-reconnect** is enabled by default. Call `disconnect` when you actually want to stop; just closing the socket will trigger a reconnect.
+- **`app_name` must match** the Stasis application in Asterisk; events from other applications are not forwarded.
+- Calling `on` after `connect` is safe — handlers are stored in a plain Hash and checked on each incoming message.
+
+## Source files
+
+- `lib/ruby-asterisk/ari/websocket.rb` — `WebSocket` class
+- `lib/ruby-asterisk/ari/websocket/connection.rb` — `Connection` module (establish, ping, reconnect)
+- `lib/ruby-asterisk/ari/websocket/event_handlers.rb` — `EventHandlers` module (dispatch callbacks)
+- `spec/ruby-asterisk/ari/websocket_spec.rb`

--- a/.claude/skills/ruby-asterisk-ari/SKILL.md
+++ b/.claude/skills/ruby-asterisk-ari/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: ruby-asterisk-ari
+description: Use the Asterisk REST Interface with ruby-asterisk: channels, bridges, playbacks, endpoints via HTTP, and RubyAsterisk::Error for 4xx/5xx handling.
+---
+
+# ruby-asterisk ARI HTTP Client
+
+## When to use this skill
+
+Use this skill when writing code that controls Asterisk channels or bridges via the ARI REST API — for example: answering calls from a Stasis application, mixing channels into a bridge, controlling media playback, or inspecting endpoint registration state.
+
+## Core concepts
+
+- The client is **synchronous** (backed by Faraday). Every method blocks and returns the parsed JSON body (Hash or Array) or raises `RubyAsterisk::Error`.
+- Resources are accessed via `Collection` objects (`client.channels`, `client.bridges`, etc.); each collection supports `list` and `get(id)`.
+- Individual resource objects have a `data` Hash with the full JSON representation, plus convenience methods for actions.
+- **`app_name`** must match the Stasis application declared in Asterisk's `ari.conf`; mismatches cause channels to be rejected or events to be silently dropped.
+
+## Initialize
+
+```ruby
+require 'ruby-asterisk'
+
+client = RubyAsterisk::ARI::Client.new(
+  'http://192.168.1.1:8088',   # ARI base URL (no trailing slash)
+  'my_api_key',                # API key used as HTTP Basic auth username
+  'my_stasis_app'              # Stasis application name
+)
+```
+
+## API reference
+
+### Asterisk info
+
+```ruby
+info = client.asterisk_info
+# => Hash with keys "build", "system", "config", "status"
+puts info['system']['version']
+```
+
+### Channels — `client.channels`
+
+| Method | Signature | Returns |
+|---|---|---|
+| `list` | — | Array of `Channel` |
+| `get` | `(id)` | `Channel` |
+
+**Channel actions:**
+
+| Method | Notes |
+|---|---|
+| `channel.id` | Channel identifier string |
+| `channel.data` | Full JSON Hash from ARI |
+| `channel.ring` | Send ringing indication |
+| `channel.answer` | Answer the channel |
+| `channel.play(media, **opts)` | Play audio; `media` = `'sound:hello-world'` |
+| `channel.hangup` | Hang up and destroy |
+
+### Bridges — `client.bridges`
+
+| Method | Signature | Returns |
+|---|---|---|
+| `list` | — | Array of `Bridge` |
+| `get` | `(id)` | `Bridge` |
+
+**Bridge actions:**
+
+| Method | Notes |
+|---|---|
+| `bridge.id` | Bridge identifier |
+| `bridge.data` | Full JSON Hash |
+| `bridge.add_channel(channel_id)` | Mix a channel into the bridge |
+| `bridge.remove_channel(channel_id)` | Remove a channel |
+| `bridge.destroy` | Destroy the bridge |
+
+### Playbacks — `client.playbacks`
+
+| Method | Signature | Returns |
+|---|---|---|
+| `get` | `(id)` | `Playback` |
+
+**Playback actions:**
+
+| Method | Notes |
+|---|---|
+| `playback.control('pause')` | Pause playback |
+| `playback.control('unpause')` | Resume |
+| `playback.control('restart')` | Restart from beginning |
+| `playback.stop` | Stop and destroy |
+
+### Endpoints — `client.endpoints`
+
+| Method | Signature | Returns |
+|---|---|---|
+| `list` | — | Array of `Endpoint` |
+
+**Endpoint attributes:**
+
+| Method | Notes |
+|---|---|
+| `ep.technology` | e.g. `'PJSIP'`, `'SIP'` |
+| `ep.resource` | e.g. `'alice'` |
+| `ep.state` | `'online'` / `'offline'` |
+| `ep.data` | Full JSON Hash |
+
+## Error handling
+
+All methods raise `RubyAsterisk::Error` for HTTP 4xx/5xx responses:
+
+```ruby
+begin
+  channel = client.channels.get('nonexistent')
+rescue RubyAsterisk::Error => e
+  puts e.message  # => "Channel not found"
+end
+```
+
+The error message comes from the JSON `message` field if present, otherwise from the HTTP reason phrase.
+
+## Usage patterns
+
+### Answer a Stasis channel and bridge two callers
+
+```ruby
+channel_a = client.channels.get(event_channel_a_id)
+channel_b = client.channels.get(event_channel_b_id)
+
+bridge = client.bridges.list.first || begin
+  # bridges.list returns all existing bridges; create via ARI REST directly if none
+end
+
+channel_a.answer
+channel_b.answer
+
+bridge.add_channel(channel_a.id)
+bridge.add_channel(channel_b.id)
+```
+
+### Play audio and track playback
+
+```ruby
+channel.play('sound:tt-monkeys', playbackId: 'pb-greeting')
+pb = client.playbacks.get('pb-greeting')
+pb.control('pause')
+sleep 2
+pb.control('unpause')
+pb.stop
+```
+
+### List all online PJSIP endpoints
+
+```ruby
+online = client.endpoints.list.select { |ep| ep.technology == 'PJSIP' && ep.state == 'online' }
+online.each { |ep| puts ep.resource }
+```
+
+## Gotchas
+
+- **Basic auth**: `api_key` is the **username**; the password is always empty (`''`). Check `ari.conf` if you get 401 errors.
+- **`app_name` must match** the Stasis application configured in Asterisk; channels not subscribed to your app will not deliver events to the WebSocket client.
+- **JSON parse fallback**: if the response body is not valid JSON, the raw string is returned instead of a Hash. This can happen with some error responses.
+- **`client.channels.list`** returns an empty array (not nil) when no channels are active.
+
+## Source files
+
+- `lib/ruby-asterisk/ari/client.rb` — `Client` class
+- `lib/ruby-asterisk/ari/resources/channel.rb` — `Channel` resource
+- `lib/ruby-asterisk/ari/resources/bridge.rb` — `Bridge` resource
+- `lib/ruby-asterisk/ari/resources/playback.rb` — `Playback` resource
+- `lib/ruby-asterisk/ari/resources/endpoint.rb` — `Endpoint` resource
+- `lib/ruby-asterisk/ari/resources/collection.rb` — `Collection` (list/get)
+- `lib/ruby-asterisk/ari/resources/base.rb` — `Base` resource (id, data)
+- `spec/ruby-asterisk/ari/client_spec.rb`
+- `spec/ruby-asterisk/ari/resources/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-05-12
+
+### Added
+
+- **AGI::Protocol** — stateless module for AGI wire protocol: `format_command`, `escape_argument`, `quote`, `parse_response`, `error?` (#55)
+- **AGI::Protocol env helpers** — `parse_env_line`, `parse_env_block`, `collect_multiline_error` for robust Asterisk environment parsing and 520 multi-line error handling (#56)
+- **AGI::Session** — full FastAGI session wrapper with fiber-friendly socket I/O: `answer`, `hangup`, `stream_file`, `say_digits`, `say_number`, `exec`, `set_variable`, `get_variable`, `get_data`, `verbose`, `dial`, `wait_for_digit`, `record_file`, `send_text`, `send_image`, `channel_status`, `database_get/put/del/deltree` (#55)
+- **AGI::Server** — FastAGI TCP server backed by Async + Fiber scheduler; each connection runs in its own Fiber sharing a single OS thread (#54)
+- **ARI::WebSocket** — WebSocket client for ARI real-time events: per-event callbacks via `on(type, &block)`, auto-reconnect, configurable ping keep-alive (#53)
+- **ARI::Client** — HTTP client for the Asterisk REST Interface backed by Faraday (#51)
+- **ARI::Resources** — Channel, Bridge, Playback, Endpoint, Collection, and Base resource classes for the ARI HTTP client (#52)
+- **AMI::Client async rewrite** — non-blocking AMI client using `SocketReaderRactor` + `ParserRactor` + `Promise`-based responses; every command returns a `Promise`, call `.value(timeout)` to materialise the `Response` (#48, #49, #50)
+- **AMI command modules** — Channel, Conference, Extension, Mailbox, Monitor, Queue, Sip, System extracted into dedicated modules and mixed into `AMI::Client` (#47)
+- `logoff` method on `AMI::Client`
+
+### Changed
+
+- **BREAKING:** `RubyAsterisk::AMI::Client` replaces the legacy flat `RubyAsterisk::AMI` class; every command now returns `RubyAsterisk::AMI::Promise` instead of a synchronous `Response`.
+- **BREAKING:** `Rami::VERSION` renamed to `RubyAsterisk::VERSION`; callers reading `Rami::VERSION` will get a `NameError`.
+- Minimum Ruby version set to 3.1.
+- Immutable domain objects (`Request`, `Response`) are now deep-frozen (#45).
+- Namespace migration: all classes moved under `RubyAsterisk::` (#46).
+
+### Fixed
+
+- Ruby 3.1 compatibility: `IO#timeout` / `IO#timeout=` shim added at the top of `agi/server.rb`; the `async` gem's Fiber scheduler calls `io.timeout` in Ruby 3.2+ — returning `nil` on 3.1 disables that code path without breaking async I/O (#55).
+- Robust Ractor cleanup and error handling on `AMI::Client#disconnect` (#50).
+
+### Removed
+
+- `Net::Telnet` dependency (replaced by raw `TCPSocket` via Ractor pipeline).
+
+---
+
+## [0.1.0]
+
+Legacy AMI client based on `Net::Telnet`. Supported: login, originate, hangup, queue operations, ConfBridge, extension state, SIP peers, device state, monitor/record, parked calls, skinny devices.
+
+> Earlier history: see `git log v0.1.0` or the [full commit list on GitHub](https://github.com/emilianodellacasa/ruby-asterisk/commits/master).

--- a/README.md
+++ b/README.md
@@ -1,349 +1,271 @@
-# RUBY-ASTERISK
+# ruby-asterisk
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/2861728929db934eb376/maintainability)](https://codeclimate.com/github/emilianodellacasa/ruby-asterisk/maintainability)
 
-This gem adds support to your Ruby or RubyOnRails projects to Asterisk Manager Interface (AMI).
+A Ruby client for [Asterisk PBX](https://www.asterisk.org/) covering three interfaces:
 
-**Note:** Version 0.2.0+ uses **Ruby Ractors** for non-blocking I/O and requires **Ruby 3.1+**.
+| Interface | Use case | Entry point | Concurrency model |
+|---|---|---|---|
+| **AMI** | TCP command/event channel | `RubyAsterisk::AMI::Client` | Ractor + Promise (non-blocking) |
+| **ARI HTTP** | REST control API | `RubyAsterisk::ARI::Client` | Synchronous (Faraday) |
+| **ARI WebSocket** | Real-time event stream | `RubyAsterisk::ARI::WebSocket` | EventMachine + Faye |
+| **AGI / FastAGI** | In-process dialplan logic | `RubyAsterisk::AGI::Server` | Async + Fibers |
+
+## Requirements
+
+- **Ruby ≥ 3.1**
+- Runtime dependencies: `async ~> 2.0`, `faraday >= 1.0`, `faye-websocket ~> 0.11`
+
+> **Ruby 3.1 note**: the `IO#timeout` shim required by the Async Fiber scheduler is applied automatically when the AGI module is loaded — no action needed.
 
 ## Installation
 
-Add to your Gemfile and run the `bundle` command to install it.
-
 ```ruby
- gem "ruby-asterisk"
+gem 'ruby-asterisk'
 ```
 
-## Usage
-
-### INITIALIZE
-
-To create a new AMI session, just call the following command:
-
-```ruby
- require 'ruby-asterisk'
- 
- # Create a client instance (uses Ractor for async reading)
- @ami = RubyAsterisk::AMI::Client.new(host: "192.168.1.1", port: 5038)
- 
- # Connect explicitly (starts the Ractor)
- @ami.connect
+```bash
+bundle install
 ```
 
-### LOGIN
+## AMI — Asterisk Manager Interface
 
-To log in, provide to the created sessions a valid username and password 
-
-```ruby
- @ami.login(username: "mark", secret: "mysecret")
-```
-
-Like all commands, it will return a Response object that could be parsed accordingly.
-
-### CORE SHOW CHANNELS
-
-To get a list of all channels currently active on your Asterisk installation, use the following command
+### Initialize and connect
 
 ```ruby
- @ami.core_show_channels
+require 'ruby-asterisk'
+
+ami = RubyAsterisk::AMI::Client.new(host: '192.168.1.1', port: 5038)
+ami.connect
 ```
 
-### PARKED CALLS
+### The Promise model
 
-To get a list of all parked calls on your Asterisk PBX, use the following command
+Every AMI command returns a `RubyAsterisk::AMI::Promise` immediately — it does **not** block. Call `.value(timeout)` to wait for the `Response`:
 
 ```ruby
- @ami.parked_calls
+promise  = ami.ping          # returns immediately
+response = promise.value     # blocks up to 5 s (default)
+response = promise.value(10) # custom timeout in seconds
+
+puts response.success        # => true
+puts response.message        # => "Pong"
+puts response.action_id      # => "lk3m0p..."
+puts response.data           # => structured Hash or Array depending on command
+puts response.raw_response   # => raw AMI text
+
+# On timeout:
+begin
+  response = promise.value(2)
+rescue Timeout::Error => e
+  puts e.message
+end
 ```
 
-### ORIGINATE
+`disconnect` rejects all pending promises with a `RuntimeError`.
 
-To start a new call use the following command
+### Login / Logoff
 
 ```ruby
- @ami.originate("SIP/9100","OUTGOING","123456","1", variable: "var1=12,var2=99") # CHANNEL, CONTEXT, CALLEE, PRIORITY, VARIABLES
+ami.login(username: 'mark', secret: 'mysecret').value
+ami.logoff.value
 ```
 
-
-### COMMAND
-
-To execute a cli command use the following code
+### System commands
 
 ```ruby
- @ami.command("core show channels")
+ami.ping.value
+ami.command('core show channels').value
+ami.wait_event(timeout: -1).value     # -1 = wait forever
+ami.event_mask('on').value            # enable event delivery on this connection
+ami.parked_calls.value
+ami.device_state_list.value
+ami.skinny_devices.value
+ami.skinny_lines.value
 ```
 
-### MEETME LIST
-
-To get a list of all active conferences use the following command
+### Channel commands
 
 ```ruby
- @ami.meet_me_list
+ami.core_show_channels.value
+ami.status.value                      # all channels
+ami.status(channel: 'SIP/alice-001').value
+
+# Originate: channel, context, callee, priority
+ami.originate('SIP/9100', 'OUTGOING', '123456', '1',
+              caller_id: 'Alice',
+              variable: 'var1=12,var2=99',
+              timeout: 30_000,
+              async: true).value
+
+# Originate to application
+ami.originate_app(channel: 'SIP/9100',
+                  application: 'Playback',
+                  data: 'hello-world',
+                  async: true).value
+
+ami.redirect('SIP/alice-001', 'default', '100', '1').value
+ami.hangup('SIP/alice-001').value
+ami.atxfer(channel: 'SIP/alice-001',
+           exten: '200',
+           context: 'default',
+           priority: '1').value
 ```
 
-### EXTENSION STATE
-
-To get the state of an extension use the following command
+### Queue commands
 
 ```ruby
- @ami.extension_state(exten: @exten, context: @context)
+ami.queues.value
+ami.queue_status.value
+ami.queue_summary('support').value
+ami.queue_add('support', 'SIP/agent1', penalty: 1, member_name: 'Alice').value
+ami.queue_remove(queue: 'support', interface: 'SIP/agent1').value
+ami.queue_pause(interface: 'SIP/agent1',
+                paused: true,
+                queue: 'support',
+                reason: 'lunch').value
 ```
 
-### DEVICE STATE LIST
-
-To get list of states of devices
+### Conference commands
 
 ```ruby
- @ami.device_state_list
+ami.meet_me_list.value
+ami.confbridges.value                          # list all ConfBridge rooms
+ami.confbridge('my-room').value                # list participants in a room
+ami.confbridge_mute(conference: 'my-room',   channel: 'SIP/alice-001').value
+ami.confbridge_unmute(conference: 'my-room', channel: 'SIP/alice-001').value
+ami.confbridge_kick(conference: 'my-room',   channel: 'SIP/alice-001').value
 ```
 
-### SKINNY DEVICES AND LINES
-
-To get list of skinny devices
+### Mailbox commands
 
 ```ruby
- @ami.skinny_devices
+ami.mailbox_status(mailbox: '1001', context: 'default').value
+ami.mailbox_count(mailbox: '1001', context: 'default').value
 ```
 
-To get list of skinny lines
+### SIP commands
 
 ```ruby
- @ami.skinny_lines
+ami.sip_peers.value
+ami.sip_show_peer('alice').value
+ami.sip_show_registry.value
 ```
 
-### QUEUE PAUSE
-                                                                                         
-To pause or unpause a member in a call queue
-                                                                                                        
-```ruby
- @ami.queue_pause(interface: "SIP/100", paused: "true", queue: "myqueue", reason: "reason")                                                                            
-```
-
-### PING
-
-To ping asterisk AMI
+### Extension state
 
 ```ruby
- @ami.ping
+response = ami.extension_state(exten: '1001', context: 'default').value
+puts response.data[:hints]
+# => [{ "Exten" => "1001", "Status" => "1",
+#        "DescriptiveStatus" => "In Use", ... }]
 ```
 
-### EVENT MASK                                                            
+Status values from `RubyAsterisk::DESCRIPTIVE_STATUS`:
+`-1` Not found · `0` Idle · `1` In Use · `2` Busy · `4` Unavailable · `8` Ringing · `16` On Hold
 
-To enable or disable sending events to this manager connection
+### Monitor commands
 
 ```ruby
- @ami.event_mask("on")
+ami.monitor('SIP/alice-001', mix: true, file: '/tmp/call', format: 'wav').value
+ami.pause_monitor('SIP/alice-001').value
+ami.unpause_monitor('SIP/alice-001').value
+ami.change_monitor(channel: 'SIP/alice-001', file: '/tmp/call2').value
+ami.stop_monitor('SIP/alice-001').value
 ```
 
-### SIPpeers
-
-To get a list of sip peers (equivalent to "sip show peers" call on the asterisk server).  This can be used to get a buddy list. 
+### Disconnect
 
 ```ruby
- @ami.sip_peers
+ami.disconnect
 ```
 
-### SIP SHOW PEER
+### The Response object
 
-To get info of a peer (equivalent to "sip show peer" call on the asterisk server).
+| Attribute | Type | Description |
+|---|---|---|
+| `success` | Boolean | `true` when raw response contains `Response: Success` |
+| `action_id` | String | ActionID echoed by Asterisk |
+| `message` | String | `Message:` field from the response |
+| `data` | Hash / Array | Structured data parsed by `ResponseParser` (see `PARSE_DATA`) |
+| `raw_response` | String/Array | The unprocessed AMI text |
+| `type` | String | The AMI action name |
 
-```ruby
- @ami.sip_show_peer(peer)
-```
+Commands with structured `data` parsing (`PARSE_DATA`): `CoreShowChannels`, `ParkedCalls`, `Originate`, `MeetMeList`, `ConfbridgeListRooms`, `ConfbridgeList`, `Status`, `ExtensionState`, `DeviceStateList`, `SKINNYdevices`, `SKINNYlines`, `QueuePause`, `Pong`, `Events`, `SIPpeers`, `SIPshowpeer`.
 
-### SIP SHOW REGISTRY
+---
 
-Retrieve a status of SIP registries and their statuses from the Asterisk server.
+## ARI — Asterisk REST Interface
 
-```ruby
- @ami.sip_show_registry
-```
-
-### STATUS
-                                                                                                                        
-To get a status of a single channel or for all channels                                                                                                                                  
-```ruby
- @ami.status 
-```
-
-### ATXFER
-
-Attendand transfer
-
-```ruby
- @ami.atxfer(channel: channel, exten: exten, context: context, priority: '1')
-```
-
-### WAIT EVENT
-
-Wait for an event to occur. Timeout in seconds to wait for events, -1 means forever
-
-```ruby
- @ami.wait_event(timeout: -1)
-```
-
-### MONITOR
-
-Monitor a channel
-
-```ruby
- @ami.monitor(channel, mix: false, file: nil, format: 'wav')
-```
-
-### STOP MONITOR
-
-Stop monitoring a channel
-
-```ruby
- @ami.stop_monitor(channel)
-```
-
-### PAUSE MONITOR
-
-Pause monitoring of a channel
-
-```ruby
- @ami.pause_monitor(channel)
-```
-
-### UNPAUSE MONITOR
-
-Unpause monitoring of a channel
-
-```ruby
- @ami.unpause_monitor(channel)
-```
-
-### CHANGE MONITOR
-
-Change monitoring filename of a channel
-
-```ruby
- @ami.change_monitor(channel: channel, file: file)
-```
-
-### DISCONNECT
-
-To close the connection and stop the Ractor:
-
-```ruby
- @ami.disconnect
-```
-
-### THE RESPONSE OBJECT
-
-The response object contains all information about all data received from Asterisk. Here follows a list of all object's properties:
-
-- type
-- success
-- action_id
-- message
-- data
-- raw_response
-
-The data property contains all additional information obtained from Asterisk, like for example the list of active channels after a "core show channels" command.
-
-## ARI (Asterisk REST Interface)
-
-Version 0.3.0+ adds an HTTP client for the [Asterisk REST Interface (ARI)](https://wiki.asterisk.org/wiki/display/AST/Getting+Started+with+ARI), which provides fine-grained, real-time call control via a REST API.
-
-### INITIALIZE ARI CLIENT
+### Initialize
 
 ```ruby
 require 'ruby-asterisk'
 
 client = RubyAsterisk::ARI::Client.new(
-  'http://192.168.1.1:8088', # ARI base URL
-  'my_api_key',              # ARI API key (username; password is empty by default)
-  'my_stasis_app'            # Stasis application name
+  'http://192.168.1.1:8088',  # ARI base URL
+  'my_api_key',               # API key (username; password is empty)
+  'my_stasis_app'             # Stasis application name
 )
 ```
 
-### ASTERISK INFO
+### Asterisk info
 
 ```ruby
 info = client.asterisk_info
-# => Hash with build, system, config, status sections
 puts info['system']['version']
 ```
 
-### CHANNELS
-
-Fetch a single channel by ID:
+### Channels
 
 ```ruby
 channel = client.channels.get('1553112062.1')
-puts channel.id          # => "1553112062.1"
-puts channel.data['name'] # => "PJSIP/alice-00000001"
-```
+puts channel.id             # => "1553112062.1"
+puts channel.data['name']   # => "PJSIP/alice-00000001"
 
-List all active channels:
-
-```ruby
 channels = client.channels.list
 channels.each { |ch| puts ch.data['name'] }
+
+channel.ring
+channel.answer
+channel.play('sound:hello-world')
+channel.play('sound:tt-monkeys', playbackId: 'pb-1')
+channel.hangup
 ```
 
-Call control actions on a channel:
+### Bridges
 
 ```ruby
-channel.ring     # send ringing indication
-channel.answer   # answer the call
-channel.play('sound:hello-world')              # play audio
-channel.play('sound:tt-monkeys', playbackId: 'pb-1') # play with options
-channel.hangup   # hang up and destroy the channel
-```
-
-### BRIDGES
-
-Create or fetch a bridge, then mix channels into it:
-
-```ruby
-# List all bridges
 bridges = client.bridges.list
+bridge  = client.bridges.get('my-bridge-id')
 
-# Fetch a specific bridge by ID
-bridge = client.bridges.get('my-bridge-id')
-
-# Add a channel to the bridge
 bridge.add_channel('1553112062.1')
-
-# Remove a channel from the bridge
 bridge.remove_channel('1553112062.1')
-
-# Destroy the bridge
 bridge.destroy
 ```
 
-### PLAYBACKS
-
-Control in-progress media playbacks:
+### Playbacks
 
 ```ruby
 playback = client.playbacks.get('pb-1')
-
-playback.control('pause')    # pause media
-playback.control('unpause')  # resume media
-playback.control('restart')  # restart from beginning
-playback.stop                # stop and destroy the playback
+playback.control('pause')
+playback.control('unpause')
+playback.control('restart')
+playback.stop
 ```
 
-### ENDPOINTS
-
-Inspect registered endpoints:
+### Endpoints
 
 ```ruby
 endpoints = client.endpoints.list
 endpoints.each do |ep|
   puts "#{ep.technology}/#{ep.resource} — #{ep.state}"
 end
-# => PJSIP/alice — online
-# => PJSIP/bob   — offline
 ```
 
-### ERROR HANDLING
+### Error handling
 
-All ARI methods raise `RubyAsterisk::Error` on HTTP 4xx/5xx responses:
+All ARI methods raise `RubyAsterisk::Error` on HTTP 4xx/5xx:
 
 ```ruby
 begin
@@ -353,8 +275,270 @@ rescue RubyAsterisk::Error => e
 end
 ```
 
+---
+
+## ARI WebSocket — Real-time events
+
+### Initialize and connect
+
+```ruby
+require 'ruby-asterisk'
+
+ws = RubyAsterisk::ARI::WebSocket.new(
+  'http://192.168.1.1:8088',
+  'my_api_key',
+  'my_stasis_app',
+  auto_reconnect: true,    # default: true
+  reconnect_delay: 5,      # seconds between attempts, default: 5
+  ping_interval: 30,       # keep-alive ping interval, default: 30
+  logger: Logger.new($stdout)
+)
+```
+
+### Register event handlers
+
+```ruby
+ws.on('StasisStart') do |event|
+  puts "Call arrived on channel #{event['channel']['id']}"
+end
+
+ws.on('ChannelStateChange') do |event|
+  puts "Channel state: #{event['channel']['state']}"
+end
+
+ws.on('StasisEnd') do |event|
+  puts "Call ended: #{event['channel']['id']}"
+end
+```
+
+Multiple handlers for the same event type are supported.
+
+### Connect and disconnect
+
+```ruby
+ws.connect do |sock|
+  puts "WebSocket connected"
+end
+
+# Check status
+ws.connected?   # => true / false
+
+# Send a message (returns false if not connected)
+ws.send_message?({ type: 'ping' })
+
+# Disconnect (disables auto-reconnect)
+ws.disconnect
+```
+
+> **Threading note**: `connect` starts an EventMachine reactor in a background thread. Event callbacks execute in that thread — avoid direct UI updates or non-thread-safe operations inside callbacks.
+
+---
+
+## AGI — FastAGI server
+
+### What is FastAGI?
+
+FastAGI lets you run the AGI dialplan logic in an external process that Asterisk connects to via TCP. ruby-asterisk provides a server that handles each Asterisk connection in its own Fiber under the `async` gem, so many concurrent calls share a single OS thread.
+
+In Asterisk's `extensions.conf`:
+
+```
+exten => 100,1,AGI(agi://192.168.1.100:4573)
+```
+
+### Initialize and start
+
+```ruby
+require 'ruby-asterisk'
+
+server = RubyAsterisk::AGI::Server.new('0.0.0.0', 4573, logger: Logger.new($stdout))
+server.handle do |session|
+  session.answer
+  session.stream_file('hello-world')
+  session.hangup
+end
+server.run   # blocks until server.stop is called
+```
+
+The handler block **must** be registered with `handle` before calling `run`, otherwise `RubyAsterisk::Error` is raised.
+
+### Ephemeral port
+
+Pass `port: 0` to bind to any free port; the actual bound port is available in `server.port` after `run` starts.
+
+### Stop
+
+```ruby
+# In a signal handler or another thread:
+server.stop
+```
+
+Active sessions finish naturally after `stop` is called.
+
+### The Session object
+
+Inside the handler block, `session` is a `RubyAsterisk::AGI::Session`. All command methods return a Hash: `{ code: Integer, result: String|nil, data: String|nil }`.
+
+**Environment**
+
+```ruby
+session.env
+# => { "agi_network" => "yes", "agi_channel" => "SIP/alice-001",
+#      "agi_callerid" => "0391234567", ... }
+```
+
+**Call control**
+
+```ruby
+session.answer
+session.hangup
+session.hangup('SIP/alice-001')   # explicit channel
+session.channel_status            # status of current channel
+session.channel_status('SIP/b')   # explicit channel
+```
+
+**Audio playback**
+
+```ruby
+session.stream_file('hello-world')          # play; no escape digits
+session.stream_file('hello-world', '1234')  # play; stop on digit 1/2/3/4
+session.say_digits('12345')
+session.say_digits('12345', '#')            # stop on #
+session.say_number(42)
+session.say_number(42, '#*')
+```
+
+**DTMF and input**
+
+```ruby
+result = session.get_data('enter-pin', timeout: 5000, max_digits: 4)
+digit  = session.wait_for_digit(5000)   # ASCII value or -1 on timeout
+```
+
+**Variables**
+
+```ruby
+session.set_variable('MY_VAR', 'hello')
+response = session.get_variable('MY_VAR')
+puts response[:data]   # => "hello"
+```
+
+**Recording**
+
+```ruby
+session.record_file('/tmp/greeting',
+                    format: 'wav',
+                    escape_digits: '#',
+                    timeout_ms: 10_000,
+                    beep: true,
+                    silence: 3)
+```
+
+**Execute dialplan application**
+
+```ruby
+session.exec('Playback', 'hello-world')
+session.dial('PJSIP/bob', timeout: 30, options: 'r')
+```
+
+**AstDB**
+
+```ruby
+session.database_put('myapp', 'last_caller', '0391234567')
+response = session.database_get('myapp', 'last_caller')
+puts response[:data]   # => "0391234567"
+session.database_del('myapp', 'last_caller')
+session.database_deltree('myapp')
+```
+
+**Logging and text**
+
+```ruby
+session.verbose('Starting IVR flow', level: 2)
+session.send_text('Hello from AGI')
+session.send_image('logo.png')
+```
+
+### IVR example — DTMF menu
+
+```ruby
+server = RubyAsterisk::AGI::Server.new('0.0.0.0', 4573)
+server.handle do |session|
+  session.answer
+
+  result  = session.get_data('ivr-menu', timeout: 5000, max_digits: 1)
+  choice  = result[:data].to_s.strip
+
+  case choice
+  when '1'
+    session.dial('PJSIP/sales', timeout: 30)
+  when '2'
+    session.dial('PJSIP/support', timeout: 30)
+  else
+    session.stream_file('invalid-option')
+  end
+
+  session.hangup
+end
+server.run
+```
+
+### Recording example — with error handling
+
+```ruby
+server = RubyAsterisk::AGI::Server.new('0.0.0.0', 4573)
+server.handle do |session|
+  session.answer
+  session.stream_file('beep')
+
+  begin
+    session.record_file('/tmp/message', format: 'wav',
+                        escape_digits: '#', timeout_ms: 30_000,
+                        beep: false, silence: 5)
+    session.database_put('voicemail', 'last_recording', '/tmp/message')
+  rescue RubyAsterisk::Error => e
+    # e.message includes the 520 multi-line error body
+    session.verbose("Recording failed: #{e.message}", level: 1)
+  end
+
+  session.hangup
+end
+server.run
+```
+
+### Error handling in sessions
+
+`session.execute` (the underlying method) raises `RubyAsterisk::Error`:
+- On EOF: `"Connection closed by Asterisk"`
+- On AGI 5xx responses, including multi-line `520-…/520 End of proper usage.` errors
+
+All command methods (`answer`, `stream_file`, etc.) are thin wrappers around `execute` and propagate the same exception.
+
+---
+
+## LLM skill files
+
+Detailed how-to guides for each subsystem are in `.claude/skills/`. Claude Code loads them automatically as project-level skills; other agent runners can read them as markdown prompts.
+
+| Skill file | Covers |
+|---|---|
+| `.claude/skills/ruby-asterisk-ami/SKILL.md` | AMI async client, Promise model, all command groups |
+| `.claude/skills/ruby-asterisk-ari/SKILL.md` | ARI HTTP client, resources, error handling |
+| `.claude/skills/ruby-asterisk-ari-websocket/SKILL.md` | ARI WebSocket events, callbacks, reconnect |
+| `.claude/skills/ruby-asterisk-agi/SKILL.md` | FastAGI server, Session verbs, IVR and recording patterns |
+
+---
+
 ## Development
 
-Questions or problems? Please post them on the [issue tracker](https://github.com/emilianodellacasa/ruby-asterisk/issues). You can contribute changes by forking the project and submitting a pull request. You can ensure the tests passing by running `bundle` and `rake`.
+```bash
+bundle install
+bundle exec rake spec     # run all tests
+bundle exec rake quality  # RuboCop checks
+```
 
-This gem is created by Emiliano Della Casa and is under the MIT License and it is distributed by courtesy of [Engim srl](http://www.engim.eu/en).
+Test infrastructure: `spec/support/mock_ami_server.rb` provides a mock AMI server for unit tests.
+
+Questions or issues? Please use the [issue tracker](https://github.com/emilianodellacasa/ruby-asterisk/issues). Contributions via fork + pull request are welcome.
+
+This gem was created by Emiliano Della Casa and is licensed under the MIT License, distributed by courtesy of [Engim srl](http://www.engim.eu/en).

--- a/lib/ruby-asterisk/version.rb
+++ b/lib/ruby-asterisk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module Rami
-  VERSION = '0.2.0'
+module RubyAsterisk
+  VERSION = '1.0.0'
 end

--- a/ruby-asterisk.gemspec
+++ b/ruby-asterisk.gemspec
@@ -5,7 +5,7 @@ require 'ruby-asterisk/version'
 
 Gem::Specification.new do |s|
   s.name        = 'ruby-asterisk'
-  s.version     = Rami::VERSION
+  s.version     = RubyAsterisk::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Emiliano Della Casa']
   s.email       = ['emiliano.dellacasa@gmail.com']


### PR DESCRIPTION
## Summary

Closes #70.

- **README rewrite**: complete overhaul covering all four interfaces (AMI, ARI HTTP, ARI WebSocket, AGI/FastAGI). New sections: Promise model for AMI async commands, ARI WebSocket events, FastAGI server setup with IVR and recording examples. All previously undocumented command groups added (queue, conference, mailbox, SIP, extension state, monitor).
- **CHANGELOG.md**: new file in Keep a Changelog format, reconstructed from git history. Documents all changes from v0.1.0 through 1.0.0 grouped by feature area.
- **LLM skill files** (`.claude/skills/`): four project-level skill files for Claude Code and other LLM agent runners (`ruby-asterisk-ami`, `ruby-asterisk-ari`, `ruby-asterisk-ari-websocket`, `ruby-asterisk-agi`). Each file covers API reference, usage patterns, and gotchas for the respective subsystem.
- **Version bump to 1.0.0**: `Rami::VERSION` renamed to `RubyAsterisk::VERSION` in `lib/ruby-asterisk/version.rb` and `ruby-asterisk.gemspec`. This is a BREAKING change for any code reading `Rami::VERSION` directly.

## Test plan

- [x] `bundle exec rake spec` — 250 examples, 0 failures
- [x] `ruby -Ilib -r ruby-asterisk -e 'puts RubyAsterisk::VERSION'` prints `1.0.0`
- [x] No remaining `Rami` references in `.rb` or `.gemspec` files
- [ ] Review README rendering on GitHub
- [ ] Verify skill files are loaded by Claude Code as project-level skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)