### PR TITLE
Issue #82 - Replace EventMachine/faye-websocket with websocket-driver for ARI WebSocket

### DIFF
--- a/.claude/skills/ruby-asterisk-ari-websocket/SKILL.md
+++ b/.claude/skills/ruby-asterisk-ari-websocket/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when you need to react to Asterisk events in real time — for ex
 
 ## Core concepts
 
-- The WebSocket client runs an **EventMachine reactor in a background thread**. `connect` returns immediately; event processing happens in that thread.
+- The WebSocket client runs a **connection thread that owns the socket read loop** (protocol handled by the pure Ruby `websocket-driver` gem — no EventMachine). `connect` returns immediately; event processing happens in that thread.
 - Register handlers with `on(event_type, &block)` before or after connecting — handlers are stored and called whenever a matching event arrives.
 - **Multiple handlers** for the same event type are supported; all are called in registration order.
 - Auto-reconnect is enabled by default. When the connection drops, the client waits `reconnect_delay` seconds and reconnects. Set `auto_reconnect: false` to disable.
@@ -129,8 +129,9 @@ sleep
 
 ## Gotchas
 
-- **`connect` is non-blocking** — it starts a background EventMachine thread and returns `self`. The main thread must stay alive (e.g. `sleep`) for the event loop to run.
-- **Callbacks execute in the EventMachine thread** — avoid long-running or blocking operations in callbacks; offload to a separate thread if needed.
+- **`connect` is non-blocking** — it starts a background connection thread and returns `self`. The main thread must stay alive (e.g. `sleep`) for events to be processed.
+- **Callbacks execute in the connection thread** — avoid long-running or blocking operations in callbacks; offload to a separate thread if needed. A blocked callback also blocks the read loop.
+- **`send_message?` is thread-safe** — outgoing writes are serialized through an internal reentrant Monitor, so it can be called from any thread (including from inside a callback).
 - **`send_message?` returns `false`** when not connected — always check the return value if delivery matters.
 - **Auto-reconnect** is enabled by default. Call `disconnect` when you actually want to stop; just closing the socket will trigger a reconnect.
 - **`app_name` must match** the Stasis application in Asterisk; events from other applications are not forwarded.
@@ -139,6 +140,9 @@ sleep
 ## Source files
 
 - `lib/ruby-asterisk/ari/websocket.rb` — `WebSocket` class
-- `lib/ruby-asterisk/ari/websocket/connection.rb` — `Connection` module (establish, ping, reconnect)
+- `lib/ruby-asterisk/ari/websocket/connection.rb` — `Connection` module (connect, read loop, reconnect)
+- `lib/ruby-asterisk/ari/websocket/heartbeat.rb` — `Heartbeat` module (ping timer, interruptible waits)
 - `lib/ruby-asterisk/ari/websocket/event_handlers.rb` — `EventHandlers` module (dispatch callbacks)
-- `spec/ruby-asterisk/ari/websocket_spec.rb`
+- `lib/ruby-asterisk/ari/websocket/socket_adapter.rb` — socket wrapper handed to `websocket-driver`
+- `spec/ruby-asterisk/ari/websocket_spec.rb` — unit specs
+- `spec/ruby-asterisk/ari/websocket_integration_spec.rb` — integration specs against `spec/support/mock_ari_websocket_server.rb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **AMI async reactor** — replaced the experimental Ractor pipeline (`SocketReaderRactor` + `ParserRactor` + event-loop Thread) with a single `Async` reactor running in a dedicated OS thread. Two cooperative Fibers (intake + reader) handle socket I/O; a pure `Parser` module handles frame parsing. Public `Client` API is unchanged; `Promise` (Mutex+CV) is unchanged. Unifies the concurrency runtime with AGI (both now use the `async` gem). Removes experimental Ractor warnings, CI GC workarounds, and the `sleep 0.2` suite teardown.
+- **ARI WebSocket without EventMachine** — replaced `faye-websocket` + `eventmachine` with the pure Ruby `websocket-driver` gem over a plain `TCPSocket` (`SSLSocket` for https): a connection thread owns connect/read-loop/auto-reconnect, a ping thread sends keep-alives, and driver access is serialized through a reentrant Monitor so `send_message?` is thread-safe. Public `WebSocket` API and wire protocol are unchanged. Fixes `bundle install` on ruby-head (4.1.0-dev), where `eventmachine` 1.2.7 no longer compiles (`Data_Wrap_Struct` removed from the C API) (#82).
+- **AMI reactor** — replaced the experimental Ractor pipeline (`SocketReaderRactor` + `ParserRactor` + event-loop Thread) with two plain OS threads (reader + writer) around a pure `Parser` module; plain Threads give deterministic shutdown on all Ruby ≥ 3.1. Public `Client` API is unchanged; `Promise` (Mutex+CV) is unchanged. Removes experimental Ractor warnings, CI GC workarounds, and the `sleep 0.2` suite teardown (#79).
 
 ## [1.0.0] - 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ A Ruby client for [Asterisk PBX](https://www.asterisk.org/) covering three inter
 
 | Interface | Use case | Entry point | Concurrency model |
 |---|---|---|---|
-| **AMI** | TCP command/event channel | `RubyAsterisk::AMI::Client` | Ractor + Promise (non-blocking) |
+| **AMI** | TCP command/event channel | `RubyAsterisk::AMI::Client` | Threads + Promise (non-blocking) |
 | **ARI HTTP** | REST control API | `RubyAsterisk::ARI::Client` | Synchronous (Faraday) |
-| **ARI WebSocket** | Real-time event stream | `RubyAsterisk::ARI::WebSocket` | EventMachine + Faye |
+| **ARI WebSocket** | Real-time event stream | `RubyAsterisk::ARI::WebSocket` | websocket-driver + Threads |
 | **AGI / FastAGI** | In-process dialplan logic | `RubyAsterisk::AGI::Server` | Async + Fibers |
 
 ## Requirements
 
 - **Ruby ≥ 3.1**
-- Runtime dependencies: `async ~> 2.0`, `faraday >= 1.0`, `faye-websocket ~> 0.11`
+- Runtime dependencies: `async ~> 2.0`, `faraday >= 1.0`, `websocket-driver ~> 0.8`
 
 > **Ruby 3.1 note**: the `IO#timeout` shim required by the Async Fiber scheduler is applied automatically when the AGI module is loaded — no action needed.
 
@@ -330,7 +330,7 @@ ws.send_message?({ type: 'ping' })
 ws.disconnect
 ```
 
-> **Threading note**: `connect` starts an EventMachine reactor in a background thread. Event callbacks execute in that thread — avoid direct UI updates or non-thread-safe operations inside callbacks.
+> **Threading note**: `connect` starts a background connection thread that owns the socket read loop. Event callbacks execute in that thread — avoid direct UI updates or non-thread-safe operations inside callbacks.
 
 ---
 

--- a/lib/ruby-asterisk/ari/websocket.rb
+++ b/lib/ruby-asterisk/ari/websocket.rb
@@ -1,19 +1,38 @@
 # frozen_string_literal: true
 
-require 'faye/websocket'
-require 'eventmachine'
+require 'websocket/driver'
+require 'socket'
+require 'openssl'
 require 'json'
 require 'uri'
 require 'logger'
+require 'monitor'
+require_relative 'websocket/socket_adapter'
 require_relative 'websocket/connection'
+require_relative 'websocket/heartbeat'
 require_relative 'websocket/event_handlers'
 
 module RubyAsterisk
   module ARI
     # WebSocket client for ARI events
     # Connects to the Asterisk ARI WebSocket endpoint to receive real-time events
+    #
+    # I/O model (no EventMachine): the WebSocket protocol is handled by the pure
+    # Ruby websocket-driver gem over a plain TCPSocket (SSLSocket for wss).
+    #
+    #   connection_thread — owns the socket lifecycle: connects, runs the read
+    #                       loop (readpartial -> driver.parse -> callbacks), and
+    #                       re-connects after a drop while auto-reconnect is on.
+    #
+    #   ping_thread       — started when the connection opens; wakes every
+    #                       ping_interval seconds and sends a WebSocket ping.
+    #
+    # Event callbacks execute in the connection thread. All driver calls are
+    # serialized through a reentrant Monitor so send_message? is safe from any
+    # thread.
     class WebSocket
       include Connection
+      include Heartbeat
       include EventHandlers
 
       attr_reader :url, :app_name, :callbacks, :connected
@@ -42,16 +61,13 @@ module RubyAsterisk
         @api_key = api_key
         @app_name = app_name
         @callbacks = {}
-        @ws = nil
         @connected = false
-        @ping_timer = nil
-        @reconnect_timer = nil
         @should_reconnect = options.fetch(:auto_reconnect, true)
         @reconnect_attempts = 0
         @logger = options[:logger] || Logger.new($stdout)
         @ping_interval = options.fetch(:ping_interval, PING_INTERVAL)
         @reconnect_delay = options.fetch(:reconnect_delay, RECONNECT_DELAY)
-        @em_thread = nil
+        initialize_io_state
       end
 
       # Connect to the WebSocket endpoint
@@ -60,15 +76,7 @@ module RubyAsterisk
       # @return [self]
       def connect(&block)
         @on_connect_callback = block
-
-        # Start EventMachine if not already running
-        unless EM.reactor_running?
-          @em_thread = Thread.new { EM.run }
-          sleep 0.1 until EM.reactor_running?
-        end
-
-        EM.next_tick { establish_connection }
-
+        @connection_thread = Thread.new { connection_loop }
         self
       end
 
@@ -89,12 +97,12 @@ module RubyAsterisk
       def disconnect
         @should_reconnect = false
         stop_ping_timer
-        stop_reconnect_timer
+        close_connection
+        wake_sleepers
 
-        if @ws
-          @ws.close
-          @ws = nil
-        end
+        thread = @connection_thread
+        @connection_thread = nil
+        thread&.join(2) unless thread == Thread.current
 
         @connected = false
         @logger.info 'WebSocket disconnected'
@@ -105,7 +113,7 @@ module RubyAsterisk
       #
       # @return [Boolean]
       def connected?
-        !!(@connected && @ws && @ws.ready_state == Faye::WebSocket::API::OPEN)
+        !!(@connected && @driver && @driver.state == :open)
       end
 
       # Send a message through the WebSocket
@@ -113,11 +121,27 @@ module RubyAsterisk
       # @param message [Hash, String] Message to send (will be converted to JSON if Hash)
       # @return [Boolean] true if sent successfully
       def send_message?(message)
-        return false unless connected?
+        driver = @driver
+        return false unless @connected && driver && driver.state == :open
 
         data = message.is_a?(Hash) ? JSON.generate(message) : message
-        @ws.send(data)
+        @driver_monitor.synchronize { driver.text(data) }
         true
+      rescue IOError, SystemCallError
+        false
+      end
+
+      private
+
+      def initialize_io_state
+        @driver = nil
+        @socket = nil
+        @connection_thread = nil
+        @ping_thread = nil
+        @ping_token = nil
+        @driver_monitor = Monitor.new
+        @wake_mutex = Mutex.new
+        @wake_cv = ConditionVariable.new
       end
     end
   end

--- a/lib/ruby-asterisk/ari/websocket/connection.rb
+++ b/lib/ruby-asterisk/ari/websocket/connection.rb
@@ -18,78 +18,119 @@ module RubyAsterisk
           "#{ws_scheme}://#{auth}#{uri.host}:#{uri.port}/ari/events?app=#{@app_name}"
         end
 
+        # Main loop of the connection thread: connect, read until the
+        # connection drops, then reconnect while auto-reconnect is enabled.
+        def connection_loop
+          loop do
+            run_connection
+            break unless @should_reconnect
+            break unless wait_before_reconnect
+          end
+        end
+
+        # Run a single connection: establish it and read until it drops.
+        def run_connection
+          establish_connection
+        rescue StandardError => e
+          @logger.error "Failed to establish connection: #{e.message}"
+        else
+          read_loop
+        ensure
+          cleanup_connection
+        end
+
         # Establish WebSocket connection
         def establish_connection
           @logger.info "Connecting to ARI WebSocket: app=#{@app_name}"
 
-          url = build_url
-          @ws = Faye::WebSocket::Client.new(url)
+          @socket = open_socket(URI.parse(@base_url))
+          @driver = ::WebSocket::Driver.client(SocketAdapter.new(build_url, @socket))
 
           setup_event_handlers
-        rescue StandardError => e
-          @logger.error "Failed to establish connection: #{e.message}"
-          schedule_reconnect
+          @driver.start
+        end
+
+        # Open a TCP socket, wrapped in TLS when the base URL is https
+        def open_socket(uri)
+          tcp = TCPSocket.new(uri.host, uri.port)
+          tcp.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+          return tcp unless uri.scheme == 'https'
+
+          context = OpenSSL::SSL::SSLContext.new
+          context.set_params
+          ssl = OpenSSL::SSL::SSLSocket.new(tcp, context)
+          ssl.hostname = uri.host
+          ssl.sync_close = true
+          ssl.connect
+          ssl
         end
 
         # Setup WebSocket event handlers
         def setup_event_handlers
-          @ws.on :open do |_event|
-            handle_open
-          end
-
-          @ws.on :message do |event|
-            handle_message(event)
-          end
-
-          @ws.on :close do |event|
-            handle_close(event)
-          end
-
-          @ws.on :error do |event|
-            handle_error(event)
-          end
+          @driver.on(:open) { |_event| handle_open }
+          @driver.on(:message) { |event| handle_message(event) }
+          @driver.on(:close) { |event| handle_close(event) }
+          @driver.on(:error) { |event| handle_error(event) }
         end
 
-        # Start the ping timer to keep connection alive
-        def start_ping_timer
+        # Feed incoming bytes to the driver until the socket closes
+        def read_loop
+          loop do
+            chunk = @socket.readpartial(4096)
+            @driver_monitor.synchronize { @driver.parse(chunk) }
+          end
+        rescue IOError, SystemCallError
+          handle_connection_lost
+        end
+
+        # The socket dropped without a WebSocket close frame
+        def handle_connection_lost
+          return unless @connected
+
+          @connected = false
           stop_ping_timer
-
-          @ping_timer = EM::PeriodicTimer.new(@ping_interval) do
-            if connected?
-              @logger.debug 'Sending ping'
-              @ws.ping
-            end
-          end
+          @logger.warn 'WebSocket connection lost'
         end
 
-        # Stop the ping timer
-        def stop_ping_timer
-          @ping_timer&.cancel
-          @ping_timer = nil
+        # Release per-connection resources after the read loop exits
+        def cleanup_connection
+          stop_ping_timer
+          close_socket
+          @driver = nil
+          @socket = nil
+          @connected = false
         end
 
-        # Schedule a reconnection attempt
-        def schedule_reconnect
-          return unless @should_reconnect
-
+        # Wait before the next reconnection attempt
+        #
+        # @return [Boolean] false when reconnection must stop
+        def wait_before_reconnect
           if MAX_RECONNECT_ATTEMPTS && @reconnect_attempts >= MAX_RECONNECT_ATTEMPTS
             @logger.error 'Max reconnection attempts reached, giving up'
-            return
+            return false
           end
 
           @reconnect_attempts += 1
           @logger.info "Scheduling reconnection attempt #{@reconnect_attempts} in #{@reconnect_delay} seconds"
 
-          stop_reconnect_timer
-          @reconnect_timer = EM::Timer.new(@reconnect_delay) do
-            establish_connection
-          end
+          wait_or_wake(@reconnect_delay)
+          @should_reconnect
         end
 
-        # Stop the reconnect timer
-        def stop_reconnect_timer
-          @reconnect_timer&.cancel
-          @reconnect_timer = nil
+        # Send a close frame (if the connection is open) and close the socket
+        def close_connection
+          driver = @driver
+          @driver_monitor.synchronize { driver.close } if driver && driver.state == :open
+        rescue StandardError
+          nil
+        ensure
+          close_socket
+        end
+
+        def close_socket
+          @socket&.close
+        rescue StandardError
+          nil
         end
       end
     end

--- a/lib/ruby-asterisk/ari/websocket/event_handlers.rb
+++ b/lib/ruby-asterisk/ari/websocket/event_handlers.rb
@@ -19,7 +19,7 @@ module RubyAsterisk
 
         # Handle incoming WebSocket message
         #
-        # @param event [Faye::WebSocket::API::Event]
+        # @param event [WebSocket::Driver::MessageEvent]
         def handle_message(event)
           data = JSON.parse(event.data)
           event_type = data['type']
@@ -32,21 +32,22 @@ module RubyAsterisk
           @logger.error "Failed to parse message: #{e.message}"
         end
 
-        # Handle WebSocket close event
+        # Handle WebSocket close event. Reconnection is handled by the
+        # connection thread once the read loop unblocks.
         #
-        # @param event [Faye::WebSocket::API::Event]
+        # @param event [WebSocket::Driver::CloseEvent]
         def handle_close(event)
           @connected = false
           stop_ping_timer
 
           @logger.warn "WebSocket closed: code=#{event.code}, reason=#{event.reason}"
 
-          schedule_reconnect if @should_reconnect
+          close_socket
         end
 
         # Handle WebSocket error event
         #
-        # @param event [Faye::WebSocket::API::Event]
+        # @param event [WebSocket::Driver::ProtocolError]
         def handle_error(event)
           @logger.error "WebSocket error: #{event.message}"
         end

--- a/lib/ruby-asterisk/ari/websocket/heartbeat.rb
+++ b/lib/ruby-asterisk/ari/websocket/heartbeat.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module ARI
+    class WebSocket
+      # Ping keep-alive timer and interruptible waits for ARI WebSocket
+      module Heartbeat
+        private
+
+        # Start the ping timer to keep connection alive
+        def start_ping_timer
+          stop_ping_timer
+
+          token = @ping_token = Object.new
+          @ping_thread = Thread.new { ping_loop(token) }
+        end
+
+        # Send a ping every @ping_interval seconds until the token is revoked
+        def ping_loop(token)
+          loop do
+            wait_or_wake(@ping_interval)
+            break unless token.equal?(@ping_token)
+            next unless connected?
+
+            @logger.debug 'Sending ping'
+            send_ping
+          end
+        end
+
+        def send_ping
+          driver = @driver
+          @driver_monitor.synchronize { driver&.ping }
+        rescue IOError, SystemCallError
+          nil
+        end
+
+        # Stop the ping timer
+        def stop_ping_timer
+          @ping_token = nil
+          @ping_thread = nil
+          wake_sleepers
+        end
+
+        # Interruptible sleep: returns early when wake_sleepers is called
+        def wait_or_wake(seconds)
+          @wake_mutex.synchronize { @wake_cv.wait(@wake_mutex, seconds) }
+        end
+
+        def wake_sleepers
+          @wake_mutex.synchronize { @wake_cv.broadcast }
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-asterisk/ari/websocket/socket_adapter.rb
+++ b/lib/ruby-asterisk/ari/websocket/socket_adapter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RubyAsterisk
+  module ARI
+    class WebSocket
+      # Minimal socket wrapper handed to WebSocket::Driver.client: the driver
+      # reads #url to build the handshake request (including Basic auth from
+      # the URL userinfo) and calls #write to emit outgoing bytes.
+      class SocketAdapter
+        attr_reader :url
+
+        def initialize(url, io)
+          @url = url
+          @io = io
+        end
+
+        def write(data)
+          @io.write(data)
+        end
+      end
+    end
+  end
+end

--- a/ruby-asterisk.gemspec
+++ b/ruby-asterisk.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'async', '~> 2.0'
   s.add_runtime_dependency 'faraday', '>= 1.0'
-  s.add_runtime_dependency 'faye-websocket', '~> 0.11'
+  s.add_runtime_dependency 'websocket-driver', '~> 0.8'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/spec/ruby-asterisk/ari/websocket_integration_spec.rb
+++ b/spec/ruby-asterisk/ari/websocket_integration_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/mock_ari_websocket_server'
+
+RSpec.describe RubyAsterisk::ARI::WebSocket, 'integration' do
+  let(:server) { MockAriWebSocketServer.new }
+  let(:base_url) { "http://127.0.0.1:#{server.port}" }
+  let(:logger) { Logger.new(File::NULL) }
+
+  after do
+    @websocket&.disconnect
+    server.stop
+  end
+
+  def connect(options = {})
+    opened = Queue.new
+    defaults = { logger: logger, reconnect_delay: 0.1 }
+    @websocket = described_class.new(base_url, 'api_key', 'test_app', defaults.merge(options))
+    yield @websocket if block_given?
+    @websocket.connect { opened << true }
+    MockAriWebSocketServer.pop(opened)
+    @websocket
+  end
+
+  it 'completes the handshake and fires the on_connect callback' do
+    websocket = connect
+
+    expect(websocket.connected?).to be(true)
+  end
+
+  it 'dispatches server events to registered callbacks' do
+    received = Queue.new
+    connect { |ws| ws.on('StasisStart') { |data| received << data } }
+
+    server.broadcast('type' => 'StasisStart', 'channel' => { 'id' => '42' })
+
+    event = MockAriWebSocketServer.pop(received)
+    expect(event).to eq('type' => 'StasisStart', 'channel' => { 'id' => '42' })
+  end
+
+  it 'sends messages to the server' do
+    websocket = connect
+
+    expect(websocket.send_message?({ 'type' => 'ping' })).to be(true)
+    expect(MockAriWebSocketServer.pop(server.messages)).to eq('{"type":"ping"}')
+  end
+
+  it 'sends pings at the configured interval' do
+    connect(ping_interval: 0.1)
+
+    expect(MockAriWebSocketServer.pop(server.pings)).not_to be_nil
+  end
+
+  it 'reconnects automatically after a connection drop' do
+    received = Queue.new
+    connect { |ws| ws.on('StasisStart') { |data| received << data } }
+    MockAriWebSocketServer.pop(server.connections) # first handshake
+
+    server.drop_clients
+    MockAriWebSocketServer.pop(server.connections) # second handshake
+
+    server.broadcast('type' => 'StasisStart')
+    expect(MockAriWebSocketServer.pop(received)).to eq('type' => 'StasisStart')
+  end
+
+  it 'does not reconnect when auto_reconnect is disabled' do
+    websocket = connect(auto_reconnect: false)
+    thread = websocket.instance_variable_get(:@connection_thread)
+
+    server.drop_clients
+
+    expect(thread.join(2)).to eq(thread)
+    expect(websocket.connected?).to be(false)
+  end
+
+  it 'stops cleanly on disconnect' do
+    websocket = connect
+    thread = websocket.instance_variable_get(:@connection_thread)
+
+    websocket.disconnect
+
+    expect(websocket.connected?).to be(false)
+    expect(thread.alive?).to be(false)
+  end
+end

--- a/spec/ruby-asterisk/ari/websocket_spec.rb
+++ b/spec/ruby-asterisk/ari/websocket_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe RubyAsterisk::ARI::WebSocket do
       end
     end
 
-    context 'when connected flag is true but no WebSocket' do
+    context 'when connected flag is true but no driver' do
       before do
         websocket.instance_variable_set(:@connected, true)
       end
@@ -94,12 +94,12 @@ RSpec.describe RubyAsterisk::ARI::WebSocket do
       end
     end
 
-    context 'when connected with WebSocket' do
-      let(:ws) { instance_double(Faye::WebSocket::Client, ready_state: Faye::WebSocket::API::OPEN) }
+    context 'when connected with an open driver' do
+      let(:driver) { instance_double(WebSocket::Driver::Client, state: :open) }
 
       before do
         websocket.instance_variable_set(:@connected, true)
-        websocket.instance_variable_set(:@ws, ws)
+        websocket.instance_variable_set(:@driver, driver)
       end
 
       it 'returns true' do
@@ -116,37 +116,42 @@ RSpec.describe RubyAsterisk::ARI::WebSocket do
     end
 
     context 'when connected' do
-      let(:ws) { instance_double(Faye::WebSocket::Client, ready_state: Faye::WebSocket::API::OPEN, send: nil) }
+      let(:driver) { instance_double(WebSocket::Driver::Client, state: :open, text: true) }
 
       before do
         websocket.instance_variable_set(:@connected, true)
-        websocket.instance_variable_set(:@ws, ws)
+        websocket.instance_variable_set(:@driver, driver)
       end
 
       it 'sends string message' do
         websocket.send_message?('test message')
-        expect(ws).to have_received(:send).with('test message')
+        expect(driver).to have_received(:text).with('test message')
       end
 
       it 'converts hash to JSON' do
         websocket.send_message?({ type: 'test', data: 'value' })
-        expect(ws).to have_received(:send).with('{"type":"test","data":"value"}')
+        expect(driver).to have_received(:text).with('{"type":"test","data":"value"}')
       end
 
       it 'returns true' do
         expect(websocket.send_message?('test')).to be(true)
       end
+
+      it 'returns false when the write raises IOError' do
+        allow(driver).to receive(:text).and_raise(IOError)
+        expect(websocket.send_message?('test')).to be(false)
+      end
     end
   end
 
   describe '#disconnect' do
-    let(:ws) { instance_double(Faye::WebSocket::Client, close: nil) }
-    let(:ping_timer) { instance_double(EM::PeriodicTimer, cancel: nil) }
+    let(:driver) { instance_double(WebSocket::Driver::Client, state: :open, close: nil) }
+    let(:socket) { instance_double(TCPSocket, close: nil) }
 
     before do
-      websocket.instance_variable_set(:@ws, ws)
+      websocket.instance_variable_set(:@driver, driver)
+      websocket.instance_variable_set(:@socket, socket)
       websocket.instance_variable_set(:@connected, true)
-      websocket.instance_variable_set(:@ping_timer, ping_timer)
     end
 
     it 'sets should_reconnect to false' do
@@ -154,14 +159,20 @@ RSpec.describe RubyAsterisk::ARI::WebSocket do
       expect(websocket.instance_variable_get(:@should_reconnect)).to be(false)
     end
 
-    it 'stops ping timer' do
+    it 'stops the ping timer' do
       websocket.disconnect
-      expect(ping_timer).to have_received(:cancel)
+      expect(websocket.instance_variable_get(:@ping_token)).to be_nil
+      expect(websocket.instance_variable_get(:@ping_thread)).to be_nil
     end
 
-    it 'closes the WebSocket' do
+    it 'sends a close frame' do
       websocket.disconnect
-      expect(ws).to have_received(:close)
+      expect(driver).to have_received(:close)
+    end
+
+    it 'closes the socket' do
+      websocket.disconnect
+      expect(socket).to have_received(:close)
     end
 
     it 'sets connected to false' do
@@ -260,7 +271,7 @@ RSpec.describe RubyAsterisk::ARI::WebSocket do
 
   describe 'private #handle_message' do
     let(:event_json) { '{"type":"StasisStart","channel":{"id":"123"}}' }
-    let(:event) { double('Faye::WebSocket::API::Event', data: event_json) }
+    let(:event) { double('WebSocket::Driver::MessageEvent', data: event_json) }
 
     it 'parses JSON and dispatches event' do
       called = false
@@ -277,7 +288,7 @@ RSpec.describe RubyAsterisk::ARI::WebSocket do
     end
 
     it 'logs error for invalid JSON' do
-      invalid_event = double('Faye::WebSocket::API::Event', data: 'invalid json')
+      invalid_event = double('WebSocket::Driver::MessageEvent', data: 'invalid json')
 
       websocket.send(:handle_message, invalid_event)
 
@@ -286,11 +297,11 @@ RSpec.describe RubyAsterisk::ARI::WebSocket do
   end
 
   describe 'private #handle_open' do
-    let(:ws) { instance_double(Faye::WebSocket::Client) }
+    let(:driver) { instance_double(WebSocket::Driver::Client) }
     let(:connect_callback) { proc { |ws| } }
 
     before do
-      websocket.instance_variable_set(:@ws, ws)
+      websocket.instance_variable_set(:@driver, driver)
       websocket.instance_variable_set(:@on_connect_callback, connect_callback)
       allow(websocket).to receive(:start_ping_timer)
     end
@@ -323,12 +334,12 @@ RSpec.describe RubyAsterisk::ARI::WebSocket do
   end
 
   describe 'private #handle_close' do
-    let(:event) { double('Faye::WebSocket::API::Event', code: 1000, reason: 'Normal closure') }
+    let(:event) { double('WebSocket::Driver::CloseEvent', code: 1000, reason: 'Normal closure') }
 
     before do
       websocket.instance_variable_set(:@connected, true)
       allow(websocket).to receive(:stop_ping_timer)
-      allow(websocket).to receive(:schedule_reconnect)
+      allow(websocket).to receive(:close_socket)
     end
 
     it 'sets connected to false' do
@@ -346,20 +357,14 @@ RSpec.describe RubyAsterisk::ARI::WebSocket do
       expect(logger).to have_received(:warn).with(/WebSocket closed/)
     end
 
-    it 'schedules reconnect if should_reconnect is true' do
+    it 'closes the socket so the read loop unblocks' do
       websocket.send(:handle_close, event)
-      expect(websocket).to have_received(:schedule_reconnect)
-    end
-
-    it 'does not schedule reconnect if should_reconnect is false' do
-      websocket.instance_variable_set(:@should_reconnect, false)
-      websocket.send(:handle_close, event)
-      expect(websocket).not_to have_received(:schedule_reconnect)
+      expect(websocket).to have_received(:close_socket)
     end
   end
 
   describe 'private #handle_error' do
-    let(:event) { double('Faye::WebSocket::API::Event', message: 'Connection failed') }
+    let(:event) { double('WebSocket::Driver::ProtocolError', message: 'Connection failed') }
 
     it 'logs error message' do
       websocket.send(:handle_error, event)

--- a/spec/support/mock_ari_websocket_server.rb
+++ b/spec/support/mock_ari_websocket_server.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'socket'
+require 'json'
+require 'websocket/driver'
+
+# Minimal in-process WebSocket server used by ARI::WebSocket integration specs.
+# Accepts connections on an ephemeral port, completes the WebSocket handshake
+# with websocket-driver in server mode, and records what clients send.
+class MockAriWebSocketServer
+  # websocket-driver server adapter: it only needs #write
+  class ServerAdapter
+    def initialize(io)
+      @io = io
+    end
+
+    def write(data)
+      @io.write(data)
+    end
+  end
+
+  ClientConnection = Struct.new(:socket, :driver)
+
+  attr_reader :port, :messages, :pings, :connections
+
+  def initialize
+    @server = TCPServer.new('127.0.0.1', 0)
+    @port = @server.addr[1]
+    @messages = Queue.new    # text frames received from clients
+    @pings = Queue.new       # ping frames received from clients
+    @connections = Queue.new # one entry per completed handshake
+    @clients = []
+    @clients_mutex = Mutex.new
+    @accept_thread = Thread.new { accept_loop }
+  end
+
+  # Send an event (Hash) to every connected client
+  def broadcast(event)
+    data = JSON.generate(event)
+    each_client { |client| client.driver.text(data) }
+  end
+
+  # Close every client socket abruptly (no close frame), simulating a drop
+  def drop_clients
+    each_client { |client| client.socket.close }
+    @clients_mutex.synchronize { @clients.clear }
+  end
+
+  def stop
+    @server.close
+    @accept_thread.join(1)
+    drop_clients
+  rescue IOError
+    nil
+  end
+
+  # Pop from one of the queues, failing the spec on timeout
+  def self.pop(queue, timeout = 5)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    loop do
+      return queue.pop(true)
+    rescue ThreadError
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        raise "timed out waiting for queue after #{timeout}s"
+      end
+
+      sleep 0.01
+    end
+  end
+
+  private
+
+  def accept_loop
+    loop do
+      socket = @server.accept
+      Thread.new { handle_client(socket) }
+    end
+  rescue IOError, SystemCallError
+    nil
+  end
+
+  def handle_client(socket)
+    driver = ::WebSocket::Driver.server(ServerAdapter.new(socket))
+    client = ClientConnection.new(socket, driver)
+    @clients_mutex.synchronize { @clients << client }
+
+    setup_driver(driver, client)
+    driver.parse(socket.readpartial(4096)) until socket.closed?
+  rescue IOError, SystemCallError
+    nil
+  ensure
+    begin
+      socket.close
+    rescue StandardError
+      nil
+    end
+  end
+
+  def setup_driver(driver, client)
+    driver.on(:connect) { driver.start if ::WebSocket::Driver.websocket?(driver.env) }
+    driver.on(:open) { @connections << client }
+    driver.on(:message) { |event| @messages << event.data }
+    driver.on(:ping) { |event| @pings << event }
+  end
+
+  def each_client
+    clients = @clients_mutex.synchronize { @clients.dup }
+    clients.each do |client|
+      yield client
+    rescue IOError, SystemCallError
+      nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #82

## Why

The `ruby head` CI job fails during `bundle install`: `eventmachine` 1.2.7 no longer compiles on ruby-head (4.1.0-dev) because `Data_Wrap_Struct` / `Data_Get_Struct` were removed from the C API. EventMachine is effectively unmaintained (last release 2018), so this becomes a hard blocker when Ruby 4.1 ships.

## What

Replaces the ARI WebSocket I/O layer: `faye-websocket` + `eventmachine` → pure Ruby **`websocket-driver`** over a plain `TCPSocket` (`SSLSocket` for https), mirroring the Thread-based design adopted for the AMI Reactor in #79.

- **connection thread** owns connect, read loop (`readpartial` → `driver.parse` → callbacks) and auto-reconnect with delay/attempt logic
- **ping thread** sends keep-alives every `ping_interval` seconds, interruptible via CV so `disconnect` is immediate
- driver access serialized through a reentrant `Monitor` → `send_message?` is thread-safe from any thread, including inside callbacks
- **public API unchanged**: `connect`, `on`, `disconnect`, `connected?`, `send_message?`, same options
- **wire protocol unchanged**: `faye-websocket` was itself an EventMachine wrapper around `websocket-driver`, so handshake (incl. Basic auth from URL userinfo) and framing are identical

## Tests

- Unit specs updated (driver doubles instead of Faye doubles)
- New integration specs against an in-process mock WebSocket server (`spec/support/mock_ari_websocket_server.rb`): handshake, event dispatch, outgoing messages, ping keep-alive, auto-reconnect after drop, no-reconnect when disabled, clean shutdown — run 5× locally with no flakes
- 262 examples, 0 failures; RuboCop clean

## Docs

README, skill file and CHANGELOG updated; stale AMI reactor references (pre-#79 Fiber wording) aligned with the current Thread-based design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)