### PR TITLE
Trigger CI on version tags so the release job can run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - master
+    # Required for the release job below: without a tags filter a tag push does
+    # not trigger this workflow at all, so `if: startsWith(github.ref,
+    # 'refs/tags/v')` would never be evaluated and no release could ever run.
+    tags:
+      - 'v*'
   pull_request:
 
 jobs:

--- a/lib/ruby-asterisk/ami/reactor.rb
+++ b/lib/ruby-asterisk/ami/reactor.rb
@@ -100,12 +100,17 @@ module RubyAsterisk
 
       private
 
+      # Both loops bind the socket to a local before their first IO call:
+      # #close_socket nils out @socket, so reading the ivar inside the loop could
+      # raise NoMethodError on nil instead of the IOError the rescues expect.
+      # A closed IO object still raises IOError, which is the intended path.
       def writer_loop
+        socket = @socket
         loop do
           cmd = @command_queue.pop
           break if cmd == :stop
 
-          @socket.write(cmd)
+          socket.write(cmd)
         rescue IOError, SystemCallError
           break # socket closed or peer reset — reader_loop handles caller notification
         end
@@ -114,18 +119,21 @@ module RubyAsterisk
       end
 
       def reader_loop
+        socket = @socket
         buffer = +''
         loop do
-          chunk = @socket.readpartial(4096)
+          chunk = socket.readpartial(4096)
           buffer << chunk
           Parser.drain(buffer) { |msg| dispatch(msg) }
         end
       rescue EOFError
-        handle_unexpected_disconnect('Disconnected: EOF from server')
+        handle_unexpected_disconnect('Disconnected: EOF from server') unless @stopping
       rescue IOError, Errno::EBADF
         handle_unexpected_disconnect('Disconnected') unless @stopping
       rescue StandardError => e
-        handle_unexpected_disconnect("Reactor read error: #{e.message}")
+        # A deliberate #stop must never surface as a disconnect: the caller is
+        # notified by Client#disconnect, which rejects with its own message.
+        handle_unexpected_disconnect("Reactor read error: #{e.message}") unless @stopping
       end
 
       # Notify the client and fail every blocked caller when the link drops

--- a/spec/ruby-asterisk/ami/reactor_spec.rb
+++ b/spec/ruby-asterisk/ami/reactor_spec.rb
@@ -53,6 +53,43 @@ RSpec.describe RubyAsterisk::AMI::Reactor do
         reactor.stop
       end.not_to raise_error
     end
+
+    # #stop closes the socket from the writer thread while the reader thread sits
+    # in readpartial: that must surface as a clean shutdown, never as a disconnect
+    # notification or a rejected promise.
+    describe 'deliberate stop' do
+      let(:disconnects) { Thread::Queue.new }
+      let(:pending_promise) do
+        RubyAsterisk::AMI::Promise.new(action_id: 'stop-race', command_type: 'Ping', timeout: 1)
+      end
+
+      def stopped_reactor
+        reactor = described_class.new('localhost', @port, on_disconnect: -> { disconnects << :called })
+        reactor.start
+        reactor.register_promise('stop-race', pending_promise)
+        reactor.send_command("Action: Ping\r\nActionID: stop-race\r\n\r\n")
+        reactor.stop
+        reactor
+      end
+
+      it 'does not notify a disconnect nor reject pending promises' do
+        stopped_reactor
+
+        expect(disconnects).to be_empty
+        expect(pending_promise).not_to be_resolved
+      end
+
+      # Replays what the reader thread does when it is scheduled only after the
+      # socket has already been closed and cleared: no notification either way.
+      it 'stays silent when the reader loop runs after the socket is gone' do
+        reactor = stopped_reactor
+
+        reactor.send(:reader_loop)
+
+        expect(disconnects).to be_empty
+        expect(pending_promise).not_to be_resolved
+      end
+    end
   end
 
   # ── command delivery ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Pushing `v1.0.0` started no workflow run at all: the `push` trigger was restricted to `branches: [master]`, with no `tags:` filter. As a result the release job condition (`if: startsWith(github.ref, 'refs/tags/v')`) was never evaluated — the job was unreachable and no gem could ever be published.

## Fix

Added the `tags: ['v*']` filter to the `push` trigger. On a tag push, `lint` and `test` run first (they carry no ref condition), then `release`, which picks up the tag's tree via `actions/checkout@v4`.

## Also fixed: flaky reactor shutdown

The first CI run on this branch failed on Ruby 3.2, unrelated to the trigger change but blocking the release:

```
1) #disconnect rejects promises that are still pending
   expected RuntimeError with message matching /disconnected/i,
   got #<RuntimeError: Reactor read error: undefined method `readpartial' for nil:NilClass>
```

`Reactor#stop` closes the socket from the writer thread while the reader thread sits in `readpartial`. Both loops read `@socket` inside the loop, but `#close_socket` nils it, so a reader thread scheduled after the close raised `NoMethodError` on nil instead of the expected `IOError` — and the generic `rescue StandardError` did not check `@stopping`, so it reported the failure through `on_disconnect` and rejected every pending promise with the wrong error.

Both loops now bind the socket to a local before their first I/O call, and all three rescues are gated on `@stopping`. Two regression specs cover it; the second one replays the reader loop after the socket is gone and fails deterministically without the fix.

## After merge

GitHub uses the workflow file present in the tag's tree, so `v1.0.0` has to be recreated on this PR's merge commit before the release job can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)